### PR TITLE
Load Adobe Launch (dtm) from delay.js

### DIFF
--- a/blocks/tag-header/tag-header.css
+++ b/blocks/tag-header/tag-header.css
@@ -24,8 +24,8 @@ main .tag-header-container > div {
 }
 
 main .tag-header {
-  background-image: rgba(0, 0, 0, 0.8);
-  background-image: linear-gradient(to right, rgba(0,0,0,0.8), rgba(0,0,0,0));
+  background-image: rgb(0 0 0 / 80%);
+  background-image: linear-gradient(to right, rgb(0 0 0 / 80%), rgb(0 0 0 / 0%));
   margin: 40px 0 16px;
 }
 

--- a/blocks/tags/tags.css
+++ b/blocks/tags/tags.css
@@ -1,5 +1,5 @@
 main .tags {
-  margin: 64px auto 0 auto;
+  margin: 64px auto 0;
   border-top: 1px solid var(--color-gray-200);
   max-width: 600px;
 }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -19,15 +19,12 @@ const loadScript = (url, attrs) => {
 };
 
 // add more delayed functionality here
-/*
-if (window.location.host.endsWith('.page') || window.location.host.startsWith('localhost')) {
-      loadScript(`https://assets.adobedtm.com/868c1e78d208/${previewLib}.min.js`);
+
+// Load Launch properties (adobedtm)
+if (window.location.host.startsWith('localhost')) {
+  loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js');
+} else if (window.location.host.endsWith('.page')) {
+  loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-166628721e50-staging.min.js');
 } else {
-      loadScript(`https://assets.adobedtm.com/868c1e78d208/${productionLib}.min.js`);
-}*/
-
-// Development
-//loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js`);
-
-// Production
-loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-3ae9c8b61452.min.js`);
+  loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-3ae9c8b61452.min.js');
+}

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -4,4 +4,27 @@ import { sampleRUM } from './lib-franklin.js';
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
+const loadScript = (url, attrs) => {
+  const head = document.querySelector('head');
+  const script = document.createElement('script');
+  script.src = url;
+  if (attrs) {
+    // eslint-disable-next-line no-restricted-syntax, guard-for-in
+    for (const attr in attrs) {
+      script.setAttribute(attr, attrs[attr]);
+    }
+  }
+  head.append(script);
+  return script;
+};
+
 // add more delayed functionality here
+/*
+if (window.location.host.endsWith('.page') || window.location.host.startsWith('localhost')) {
+      loadScript(`https://assets.adobedtm.com/868c1e78d208/${previewLib}.min.js`);
+} else {
+      loadScript(`https://assets.adobedtm.com/868c1e78d208/${productionLib}.min.js`);
+}*/
+
+// Development
+loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js`);

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -27,7 +27,7 @@ if (window.location.host.endsWith('.page') || window.location.host.startsWith('l
 }*/
 
 // Development
-loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js`);
+//loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js`);
 
 // Production
 loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-3ae9c8b61452.min.js`);

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -28,3 +28,6 @@ if (window.location.host.endsWith('.page') || window.location.host.startsWith('l
 
 // Development
 loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js`);
+
+// Production
+loadScript(`https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-3ae9c8b61452.min.js`);


### PR DESCRIPTION
This loads the Adobe Launch configuration, a different launch environment based on the url (localhost-dev; .page-stage; .live-prod)

I've confirmed that data is getting in there, but the launch properties are not completely configured, the rest can be done in Adobe Analytics. 

Using my old MSA instance (ags734), may need to move at some point, but this one was available.

Fix #41 

Test URLs:
- Before: https://main--inside-aem--adobe.hlx.page/
- After: https://analytics--inside-aem--adobe.hlx.page/
