### PR TITLE
remove social media share links

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -154,21 +154,6 @@ main .article-byline .article-byline-sharing svg {
   width: 22px;
 }
 
-main .article-byline .article-byline-sharing a[data-href*="twitter"]:hover svg,
-main .article-byline .article-byline-sharing a[data-href*="twitter"]:focus svg {
-  fill: #1DA1F2;
-}
-
-main .article-byline .article-byline-sharing a[data-href*="linkedin"]:hover svg,
-main .article-byline .article-byline-sharing a[data-href*="linkedin"]:focus svg {
-  fill: #0077b5;
-}
-
-main .article-byline .article-byline-sharing a[data-href*="facebook"]:hover svg,
-main .article-byline .article-byline-sharing a[data-href*="facebook"]:focus svg {
-  fill: #3b5998;
-}
-
 main .article-byline .article-byline-sharing a#copy-to-clipboard {
   position: relative;
 }

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -91,21 +91,6 @@ async function buildSharing() {
   const placeholders = await fetchPlaceholders();
   sharing.classList.add('article-byline-sharing');
   sharing.innerHTML = `<span>
-      <a data-type="Twitter" data-href="https://www.twitter.com/share?&url=${url}&text=${title}" alt="${placeholders['share-twitter']}" aria-label="${placeholders['share-twitter']}">
-        ${createSVG('twitter').outerHTML}
-      </a>
-    </span>
-    <span>
-      <a data-type="LinkedIn" data-href="https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}&summary=${description || ''}" alt="${placeholders['share-linkedin']}" aria-label="${placeholders['share-linkedin']}">
-        ${createSVG('linkedin').outerHTML}
-      </a>
-    </span>
-    <span>
-      <a data-type="Facebook" data-href="https://www.facebook.com/sharer/sharer.php?u=${url}" alt="${placeholders['share-facebook']}" aria-label="${placeholders['share-facebook']}">
-        ${createSVG('facebook').outerHTML}
-      </a>
-    </span>
-    <span>
       <a id="copy-to-clipboard" alt="${placeholders['copy-to-clipboard']}" aria-label="${placeholders['copy-to-clipboard']}">
         ${createSVG('link').outerHTML}
       </a>

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -9,7 +9,6 @@ import {
 
 import {
   createOptimizedPicture,
-  getMetadata,
 } from '../../scripts/lib-franklin.js';
 
 async function populateAuthorInfo(authorLink, imgContainer, url, name, eager = false) {
@@ -84,9 +83,6 @@ function copyToClipboard(button) {
 }
 
 async function buildSharing() {
-  const url = encodeURIComponent(window.location.href);
-  const title = encodeURIComponent(document.querySelector('h1').textContent);
-  const description = encodeURIComponent(getMetadata('description'));
   const sharing = document.createElement('div');
   const placeholders = await fetchPlaceholders();
   sharing.classList.add('article-byline-sharing');


### PR DESCRIPTION
Remove social media share links (leave copy url to clipboard)

Fix #27 

Test URLs:
- Before: https://main--inside-aem--adobe.hlx.live/en/publish/2023/05/01/aem-pla-blog-mini-video-on-migrating-a-site-to-franklin-by-hannes-hertach
- After: https://issue-27-social--inside-aem--adobe.hlx.live/en/publish/2023/05/01/aem-pla-blog-mini-video-on-migrating-a-site-to-franklin-by-hannes-hertach
