### PR TITLE
Fix Analytics for Web

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -24,7 +24,6 @@ async function loadScript(src, parent, attrs) {
   });
 }
 
-
 // Load Launch properties (adobedtm)
 if (window.location.host.startsWith('localhost')) {
   await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-d6a3331d6f80-development.min.js', 'head', { async: true });

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -4,25 +4,32 @@ import { sampleRUM } from './lib-franklin.js';
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-const loadScript = (url, attrs) => {
-  const head = document.querySelector('head');
-  const script = document.createElement('script');
-  script.src = url;
-  if (attrs) {
-    // eslint-disable-next-line no-restricted-syntax, guard-for-in
-    for (const attr in attrs) {
-      script.setAttribute(attr, attrs[attr]);
+async function loadScript(src, parent, attrs) {
+  return new Promise((resolve, reject) => {
+    if (!document.querySelector(`${parent} > script[src="${src}"]`)) {
+      const script = document.createElement('script');
+      script.src = src;
+      if (attrs) {
+        // eslint-disable-next-line no-restricted-syntax, guard-for-in
+        for (const attr in attrs) {
+          script.setAttribute(attr, attrs[attr]);
+        }
+      }
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.append(script);
+    } else {
+      resolve();
     }
-  }
-  head.append(script);
-  return script;
-};
+  });
+}
+
 
 // Load Launch properties (adobedtm)
 if (window.location.host.startsWith('localhost')) {
-  loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js');
 } else if (window.location.host.endsWith('.page')) {
-  loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-166628721e50-staging.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-166628721e50-staging.min.js');
 } else {
-  loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-3ae9c8b61452.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-3ae9c8b61452.min.js');
 }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -27,9 +27,9 @@ async function loadScript(src, parent, attrs) {
 
 // Load Launch properties (adobedtm)
 if (window.location.host.startsWith('localhost')) {
-  await loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-6005424708d4-development.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-d6a3331d6f80-development.min.js');
 } else if (window.location.host.endsWith('.page')) {
-  await loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-166628721e50-staging.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-c00a655544fd-staging.min.js');
 } else {
   await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-9476d77cdb4e.min.js');
 }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -27,9 +27,9 @@ async function loadScript(src, parent, attrs) {
 
 // Load Launch properties (adobedtm)
 if (window.location.host.startsWith('localhost')) {
-  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-d6a3331d6f80-development.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-d6a3331d6f80-development.min.js', 'head', { async: true });
 } else if (window.location.host.endsWith('.page')) {
-  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-c00a655544fd-staging.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-c00a655544fd-staging.min.js', 'head', { async: true });
 } else {
-  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-9476d77cdb4e.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-9476d77cdb4e.min.js', 'head', { async: true });
 }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -31,5 +31,5 @@ if (window.location.host.startsWith('localhost')) {
 } else if (window.location.host.endsWith('.page')) {
   await loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-166628721e50-staging.min.js');
 } else {
-  await loadScript('https://assets.adobedtm.com/6a74768abd57/a692f024da9a/launch-3ae9c8b61452.min.js');
+  await loadScript('https://assets.adobedtm.com/6a74768abd57/ebbe34171c73/launch-9476d77cdb4e.min.js');
 }


### PR DESCRIPTION
Update with a Launch Property that uses a report suite that was created with the deafult(and not template) which fixes the issue where non-mobile traffic is not tracked.

Test URLs:
- Before: https://main--inside-aem--adobe.hlx.live/
- After: https://analytics-5--inside-aem--adobe.hlx.live/
