### PR TITLE
feat: iframe block

### DIFF
--- a/blocks/iframe/iframe.css
+++ b/blocks/iframe/iframe.css
@@ -1,7 +1,10 @@
+main .section > div.iframe-wrapper {
+  max-width: 1000px;
+}
 
 main iframe {
   border: none;
   width: 100%;
-  height: 600px;
+  height: 4000px;
   max-height: calc(100vh - var(--nav-height));
 }

--- a/blocks/iframe/iframe.css
+++ b/blocks/iframe/iframe.css
@@ -1,10 +1,14 @@
-main .section > div.iframe-wrapper {
-  max-width: 1000px;
-}
+@media (min-width: 100px) {
+  main .section > div.iframe-wrapper {
+    margin: 0 auto;
+    padding: 0;
+    max-width: 1000px;
+  }
 
-main iframe {
-  border: none;
-  width: 100%;
-  height: 4000px;
-  max-height: calc(100vh - var(--nav-height));
+  main iframe {
+    border: none;
+    width: 100%;
+    height: 4000px;
+    max-height: calc(100vh - var(--nav-height));
+  }
 }

--- a/blocks/iframe/iframe.css
+++ b/blocks/iframe/iframe.css
@@ -1,0 +1,7 @@
+
+main iframe {
+  border: none;
+  width: 100%;
+  height: 600px;
+  max-height: calc(100vh - var(--nav-height));
+}

--- a/blocks/iframe/iframe.js
+++ b/blocks/iframe/iframe.js
@@ -1,0 +1,7 @@
+export default function decorate(block) {
+  const iframe = document.createElement('iframe');
+  iframe.src = new URL(block.textContent.trim());
+  iframe.sandbox = 'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms allow-storage-access-by-user-activation';
+  block.innerHTML = '';
+  block.append(iframe);
+}


### PR DESCRIPTION
Adds ability to include full-width (and reasonable height) 3rd party URLs (e.g. MS office forms)

Test URLs:
- Before: https://main--inside-aem--adobe.hlx.page/en/drafts/blog-draft-rofe
- After: https://iframe--inside-aem--adobe.hlx.page/en/drafts/blog-draft-rofe
