### PR TITLE
fix: resolve JS and CSS lint errors across blocks

### DIFF
--- a/blocks/article-feed/article-feed.css
+++ b/blocks/article-feed/article-feed.css
@@ -448,7 +448,7 @@ main .article-feed .load-more {
   flex-direction: column;
   background: var(--color-white);
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
   overflow: hidden;
   transition: all 0.3s ease;
   text-decoration: none;
@@ -456,7 +456,7 @@ main .article-feed .load-more {
 }
 
 .newsletter-landing main .article-card:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 15%);
   transform: translateY(-4px);
 }
 
@@ -500,7 +500,7 @@ main .article-feed .load-more {
 .newsletter-landing main .article-card-body h3 {
   font-size: var(--heading-font-size-s);
   color: var(--color-black);
-  margin: 0 0 12px 0;
+  margin: 0 0 12px;
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 2;

--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -215,7 +215,9 @@ main .article-byline .article-byline-sharing .applause-inline-wrapper {
 main .article-byline .article-byline-sharing .applause-inline-wrapper applause-button {
   margin: 0 !important;
   padding: 0 !important;
-  --applause-button-color: #000000;
+
+  --applause-button-color: #000;
+
   display: flex !important;
   align-items: center !important;
   width: auto !important;
@@ -238,7 +240,7 @@ main .article-byline .article-byline-sharing .applause-inline-wrapper applause-b
   margin: 0 !important;
   font-size: 16px !important;
   font-weight: 600 !important;
-  color: #000000 !important;
+  color: #000 !important;
   line-height: 1 !important;
   white-space: nowrap !important;
 }

--- a/blocks/article-header/article-header.js
+++ b/blocks/article-header/article-header.js
@@ -97,7 +97,7 @@ function loadApplauseButtonLibrary() {
   const script = document.createElement('script');
   script.src = 'https://unpkg.com/applause-button@latest/dist/applause-button.js';
   document.head.appendChild(script);
-  
+
   // Add custom style override after library loads
   script.onload = () => {
     const style = document.createElement('style');
@@ -124,7 +124,7 @@ async function buildSharing() {
   const sharing = document.createElement('div');
   const placeholders = await fetchPlaceholders();
   sharing.classList.add('article-byline-sharing');
-  
+
   // Create applause button
   const applauseSpan = document.createElement('span');
   applauseSpan.classList.add('applause-inline-wrapper');
@@ -134,17 +134,17 @@ async function buildSharing() {
   applauseButton.setAttribute('multiclap', 'true');
   applauseButton.setAttribute('color', '#1473E6');
   applauseSpan.appendChild(applauseButton);
-  
+
   // Create copy link button
   const copySpan = document.createElement('span');
   copySpan.innerHTML = `<a id="copy-to-clipboard" alt="${placeholders['copy-to-clipboard']}" aria-label="${placeholders['copy-to-clipboard']}">
         ${createSVG('link').outerHTML}
       </a>`;
-  
+
   // Assemble sharing section
   sharing.appendChild(applauseSpan);
   sharing.appendChild(copySpan);
-  
+
   sharing.querySelectorAll('[data-href]').forEach((link) => {
     link.addEventListener('click', openPopup);
   });
@@ -152,10 +152,10 @@ async function buildSharing() {
   copyButton.addEventListener('click', () => {
     copyToClipboard(copyButton);
   });
-  
+
   // Load the applause button library
   loadApplauseButtonLibrary();
-  
+
   return sharing;
 }
 

--- a/blocks/featured-article/featured-article.css
+++ b/blocks/featured-article/featured-article.css
@@ -232,7 +232,7 @@ main .tag-header-container .featured-article-card-body p:not(:first-child) {
 .newsletter-landing main .featured-article-card {
   background-color: var(--color-white);
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
   overflow: hidden;
   max-width: 1200px;
   margin: 0 auto;
@@ -241,7 +241,7 @@ main .tag-header-container .featured-article-card-body p:not(:first-child) {
 }
 
 .newsletter-landing main .featured-article-card:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 15%);
   transform: translateY(-2px);
   transition: all 0.3s ease;
 }

--- a/blocks/featured-articles/featured-articles.js
+++ b/blocks/featured-articles/featured-articles.js
@@ -11,18 +11,18 @@ async function decorateFeaturedArticles(featuredArticlesEl, articlePaths, eager 
 
   const tagHeader = document.querySelector('.tag-header-container > div');
 
-  for (const articlePath of articlePaths) {
-    const article = await getBlogArticle(articlePath);
+  const articles = await Promise.all(articlePaths.map((path) => getBlogArticle(path)));
+  const { origin } = new URL(window.location.href);
+  articles.forEach((article, i) => {
     if (article) {
       const card = buildArticleCard(article, 'featured-article', eager);
-      card.classList.add('featured-article-card'); // Ensure the card has the correct class
+      card.classList.add('featured-article-card');
       featuredArticlesEl.append(card);
     } else {
-      const { origin } = new URL(window.location.href);
       // eslint-disable-next-line no-console
-      console.warn(`Featured article does not exist or is missing in index: ${origin}${articlePath}`);
+      console.warn(`Featured article does not exist or is missing in index: ${origin}${articlePaths[i]}`);
     }
-  }
+  });
 
   if (tagHeader) {
     tagHeader.append(featuredArticlesEl);

--- a/blocks/fluffyjaws/fluffyjaws-header.js
+++ b/blocks/fluffyjaws/fluffyjaws-header.js
@@ -160,14 +160,15 @@ export default async function decorateArticleHeader(blockEl, blockName, eager) {
   }
 
   // author
-  const author = bylineContainer && bylineContainer.firstElementChild && bylineContainer.firstElementChild.firstElementChild;
+  const bylineInfo = bylineContainer && bylineContainer.firstElementChild;
+  const author = bylineInfo && bylineInfo.firstElementChild;
   const authorLink = author ? author.querySelector('a') : null;
   const authorURL = authorLink ? authorLink.href : '#';
   const authorName = author ? author.textContent.trim() : 'Author';
   if (author) author.classList.add('article-author');
 
   // publication date
-  const date = bylineContainer && bylineContainer.firstElementChild && bylineContainer.firstElementChild.lastElementChild;
+  const date = bylineInfo && bylineInfo.lastElementChild;
   if (date) {
     date.classList.add('article-date');
     validateDate(date);

--- a/blocks/tags/tags.js
+++ b/blocks/tags/tags.js
@@ -3,10 +3,8 @@ export default function decorateTags(blockEl) {
   const container = blockEl.querySelector('p');
   container.classList.add('tags-container');
   container.textContent = '';
-  const target = Array.from(tags).reduce((targets, tag) => {
+  Array.from(tags).forEach((tag) => {
     tag.classList.add('button');
     container.append(tag);
-    targets.push(tag.textContent);
-    return targets;
-  }, []).join('; ');
+  });
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -594,6 +594,8 @@ main .section.carousel-container {
   }
 }
 
+/* stylelint-disable no-descending-specificity -- theme overrides are intentionally ordered by theme */
+
 /* Fact-box width override */
 .fact-box main,
 .fact-box main .section,
@@ -680,3 +682,4 @@ main .section.carousel-container {
   margin-bottom: 64px;
 }
 
+/* stylelint-enable no-descending-specificity */


### PR DESCRIPTION
## Summary
- **article-header.js**: remove trailing whitespace on 7 lines
- **featured-articles.js**: replace `for...of` + `await` with `Promise.all`, add trailing newline
- **fluffyjaws-header.js**: fix lines exceeding 100-char max-len, add trailing newline
- **tags.js**: remove unused `target` variable, simplify to `forEach`
- **article-feed.css**: modern color-function notation, shorthand fix
- **article-header.css**: short hex colors, empty line before custom property
- **featured-article.css**: modern color-function notation
- **styles.css**: disable false-positive descending-specificity for theme overrides

Before: https://main--inside-aem--adobe.aem.page/
After: https://fix-lint-errors--inside-aem--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)