### PR TITLE
fix: remove console.debug noise from unknown taxonomy topics

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -104,7 +104,7 @@ export function getRootPath() {
  * @param {string} topic The topic name
  * @returns {string} A link tag as a string
  */
-export function getLinkForTopic(topic, path) {
+export function getLinkForTopic(topic) {
   // temporary title substitutions
   const titleSubs = {
     'Transformation digitale': 'Transformation numérique',
@@ -115,8 +115,6 @@ export function getLinkForTopic(topic, path) {
     if (tax) {
       catLink = tax.link;
     } else {
-      // eslint-disable-next-line no-console
-      console.debug(`Trying to get a link for an unknown topic: ${topic} ${path ? `on page ${path}` : '(current page)'}`);
       catLink = '#';
     }
   }
@@ -362,7 +360,7 @@ export function decorateMain(main) {
  * @param {Array} topics List of topics
  * @returns {Object} Taxonomy object
  */
-function computeTaxonomyFromTopics(topics, path) {
+function computeTaxonomyFromTopics(topics) {
   // no topics: default to a randomly choosen category
   const category = topics?.length > 0 ? topics[0] : 'news';
   if (taxonomy && topics) {
@@ -386,9 +384,6 @@ function computeTaxonomyFromTopics(topics, path) {
             });
           }
         }
-      } else {
-        // eslint-disable-next-line no-console
-        console.debug(`Unknown topic in tags list: ${tag} ${path ? `on page ${path}` : '(current page)'}`);
       }
     });
     return {


### PR DESCRIPTION
## Summary
- Removes two `console.debug` calls in `scripts/scripts.js` that fired for every article tag not found in the loaded taxonomy
- The fallback behaviour (graceful skip / `#` link) was already correct — the log messages added no value in production and were flooding the browser console
- Also cleans up the now-unused `path` parameter from `getLinkForTopic()` and `computeTaxonomyFromTopics()`

## Test plan
- [ ] Open any article page and check the browser console — no more "Unknown topic in tags list" warnings
- [ ] Article feeds, tag pills, and category links still render correctly
- [ ] Preview: https://fix-console-noise--inside-aem--adobe.hlx.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)