### PR TITLE
style: match inline code styling to block code

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -186,7 +186,7 @@ code, pre, samp {
 
 code, samp {
   background-color: var(--overlay-background-color);
-  padding: .125em .25em;
+  padding: 1em;
   border-radius: .25em;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -185,7 +185,9 @@ code, pre, samp {
 }
 
 code, samp {
-  padding: .125em;
+  background-color: var(--overlay-background-color);
+  padding: .125em .25em;
+  border-radius: .25em;
 }
 
 pre {
@@ -761,7 +763,8 @@ main .section.carousel-container {
     color: #e0e0e0;
   }
 
-  main pre {
+  main pre,
+  code, samp {
     background-color: #1e1e1e;
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -190,6 +190,12 @@ code, samp {
   border-radius: .25em;
 }
 
+pre code, pre samp {
+  padding: 0;
+  background-color: transparent;
+  border-radius: 0;
+}
+
 pre {
   overflow: scroll;
 }


### PR DESCRIPTION
Give inline `<code>` the same background and rounded corners as block `<pre>`, in both light and dark mode.

Preview: https://style-inline-code--inside-aem--adobe.aem.page/

🤖 Generated with Claude Code