### PR TITLE
refactor(aicoc): drop hero figure; let picture flow in body

### DIFF
--- a/blocks/session-header/session-header.js
+++ b/blocks/session-header/session-header.js
@@ -142,10 +142,14 @@ export default function decorate(block) {
   const description = getMetadata('description');
   const tags = getMetadata('article:tag', true) || [];
 
-  // Borrow the h1 + first picture from <main> so they don't appear twice.
+  // Borrow the h1 from <main>. The first picture has already been moved into
+  // the block by buildSessionHeader() in scripts.js (it has to happen there,
+  // before buildImageBlocks wraps the picture in an <images> block which our
+  // decorator would otherwise fail to find).
   const main = block.closest('main') || document.querySelector('main');
   const h1 = main.querySelector('h1');
-  const heroPicture = main.querySelector('picture');
+  const figureSlot = block.querySelector('.session-header-figure-slot');
+  const heroPicture = figureSlot ? figureSlot.querySelector('picture') : null;
 
   // Fall back to author when presenter wasn't filled in.
   const presenterText = meta.presenter || author || '';
@@ -194,9 +198,9 @@ export default function decorate(block) {
   const hero = el('div', { class: 'session-header-hero' }, heroInner);
 
   // ── Hero figure ──────────────────────────────────────────────────────
-  // If the doc has a hero picture (the first <picture> in <main>), place
-  // it inside the hero on the right side as a focal card, and remove the
-  // original from <main> so the doc doesn't show it twice in the body.
+  // The picture was moved into the block by buildSessionHeader() before
+  // buildImageBlocks could touch it, so it's just sitting in figureSlot.
+  // Build the right-side figure card from it and clean up the slot.
   if (heroPicture) {
     const img = heroPicture.querySelector('img');
     if (img && img.src) {
@@ -206,23 +210,9 @@ export default function decorate(block) {
       figure.append(optimised);
       hero.append(figure);
       hero.classList.add('has-figure');
-
-      // Remove the original picture from <main>. Walk up to the nearest
-      // wrapping <p> or <div> that exists solely to hold this picture and
-      // drop it; if the wrapper has other text/content we leave it alone
-      // and just yank the picture node itself.
-      const wrapper = heroPicture.parentElement;
-      heroPicture.remove();
-      if (
-        wrapper
-        && wrapper !== main
-        && !wrapper.textContent.trim()
-        && wrapper.children.length === 0
-      ) {
-        wrapper.remove();
-      }
     }
   }
+  if (figureSlot) figureSlot.remove();
 
   // ── Final assembly ────────────────────────────────────────────────────
   block.innerHTML = '';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -262,12 +262,31 @@ function buildImageBlocks(mainEl) {
  * @param {Element} main The container element
  */
 function buildSessionHeader(mainEl) {
-  // Placeholder block. The actual hero (presenter, date, recording CTA, deck,
-  // Slack) is composed by blocks/session-header/session-header.js, which reads
-  // page metadata directly. We just mark the slot at the top of <main>.
+  // The actual hero (presenter, date, recording CTA, deck, Slack, figure
+  // image) is composed by blocks/session-header/session-header.js. We do
+  // two things here, BEFORE the rest of buildAutoBlocks runs:
+  //   1. Insert the session-header block placeholder at the top of <main>.
+  //   2. Move the first <picture>'s paragraph into the block as a slot.
+  //      We have to grab the picture here — buildImageBlocks runs later in
+  //      buildAutoBlocks and replaces <p><picture></p> with an <images>
+  //      block, which we don't want to touch. The decorator reads the
+  //      stashed picture from the block instead of re-querying <main>.
   const div = document.createElement('div');
-  div.append(buildBlock('session-header', { elems: [] }));
+  const block = buildBlock('session-header', { elems: [] });
+  div.append(block);
   mainEl.prepend(div);
+
+  const heroPicture = mainEl.querySelector('picture');
+  if (heroPicture) {
+    const wrapper = heroPicture.closest('p') || heroPicture.parentElement;
+    if (wrapper && wrapper !== mainEl) {
+      const slot = document.createElement('div');
+      slot.className = 'session-header-figure-slot';
+      slot.hidden = true;
+      slot.append(wrapper);
+      block.append(slot);
+    }
+  }
 }
 
 function buildAutoBlocks(main) {


### PR DESCRIPTION
## Summary

Follow-up to #93. The original session-header hero included a right-side **figure card** showing the doc's first picture. After seeing it live the verdict was: too much hero, too tall, picture trapped in a 320px box.

**New direction: drop the figure card entirely.** The hero contains only structured content (breadcrumb, pills, title, description, meta row, CTAs) and ends cleanly after the CTAs. Any pictures in the doc stay where the author put them — they render in the body section below the hero, like normal article content. No special handling, no extraction, no figure slot.

## Two commits, ending state

| Commit | What it did | Status |
|---|---|---|
| `ba32019` | Tried to fix the picture by extracting it earlier in the lifecycle | Superseded |
| `0a9b538` | Dropped the figure logic entirely | **This is the final state** |

The diff against `main` is small: just remove the figure code.

## What's removed

- `buildSessionHeader` picture extraction + figure slot (scripts.js)
- `session-header.js` figure-card construction + `createOptimizedPicture` import
- `.session-header-figure*` CSS + `.has-figure` desktop overrides
- 120px hero bottom padding (back to 64px on desktop)

Net: 14 insertions, 114 deletions across 3 files.

## Test URLs

- **Before** (current main, has the broken figure-card code): https://main--inside-aem--adobe.aem.live/en/aicoc/easymcp-desktop
- **After** (this branch): https://fix-aicoc-hero-picture--inside-aem--adobe.aem.live/en/aicoc/easymcp-desktop — hero ends cleanly after the CTA row, picture appears in body

## Test plan

- [ ] Session page hero ends after the CTA row (no figure card on the right on desktop, no stacked figure on mobile)
- [ ] Picture in the doc renders in the body section below the hero like a normal images block
- [ ] Hero height is shorter than before
- [ ] Hub card thumbnail (`/en/aicochub`) still works — that's driven by `og:image` independently and is unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)