### PR TITLE
refactor(aicoc): drop hero figure entirely; picture flows in body

### DIFF
--- a/blocks/session-header/session-header.css
+++ b/blocks/session-header/session-header.css
@@ -41,45 +41,8 @@ main .session-header {
   pointer-events: none;
 }
 
-/* Hero figure (the first picture from the doc, placed on the right of the
- * hero as a focal card). On mobile it stacks below the content. On desktop
- * it's absolutely positioned in the bottom-right (see media query below).
- *
- * Sizing rules: the picture must FIT — never be cut. We give the figure a
- * fixed width and a generous max-height; object-fit: contain on the <img>
- * preserves aspect for both wide (banner-style) and tall (portrait) images.
- * Any unused space inside the rounded card shows the dark backdrop, which
- * blends with the hero's deep red gradient. */
-.session-header-figure {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 28px 0 0;
-  padding: 0;
-  width: 100%;
-  max-height: 380px;
-  border-radius: 12px;
-  overflow: hidden;
-  background: #1a0606;
-  box-shadow: 0 12px 40px rgb(0 0 0 / 35%);
-}
-
-.session-header-figure picture {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  max-height: 380px;
-}
-
-.session-header-figure img {
-  display: block;
-  width: auto;
-  height: auto;
-  max-width: 100%;
-  max-height: 380px;
-  object-fit: contain;
-}
+/* The hero deliberately doesn't carry an image — pictures from the doc
+ * flow in the body below, as normal article content. */
 
 .session-header-inner {
   position: relative;
@@ -264,35 +227,9 @@ main .session-header .btn-tertiary {
   border-color: rgb(255 255 255 / 30%);
 }
 
-/* ── DESKTOP: figure floats on the right INSIDE the hero ──────────────── */
+/* ── DESKTOP ───────────────────────────────────────────────────────────── */
 @media (min-width: 960px) {
-  /* Anchor for the absolutely-positioned figure so it sits within the hero
-   * picture, not below it. */
-  main .session-header {
-    position: relative;
-  }
-
   .session-header-hero {
-    /* Extra bottom padding leaves room for the figure card to fit inside
-     * the hero without poking out the bottom. */
-    padding: 80px 48px 120px;
-  }
-
-  /* When the doc has a hero picture, the meta row and CTA row leave a lane
-   * on the right so they don't run under the figure. Title and description
-   * always span the full hero width. */
-  .session-header.has-figure .session-header-meta-row-inline,
-  .session-header.has-figure .session-header-ctas {
-    max-width: calc(100% - 360px);
-  }
-
-  /* The figure card itself: bottom-right of the hero, 320px wide. */
-  .session-header.has-figure .session-header-figure {
-    position: absolute;
-    right: 48px;
-    bottom: 48px;
-    width: 320px;
-    margin: 0;
-    z-index: 2;
+    padding: 80px 48px 64px;
   }
 }

--- a/blocks/session-header/session-header.js
+++ b/blocks/session-header/session-header.js
@@ -1,4 +1,4 @@
-import { getMetadata, createOptimizedPicture, decorateIcons } from '../../scripts/lib-franklin.js';
+import { getMetadata, decorateIcons } from '../../scripts/lib-franklin.js';
 
 // Icon markers — replaced with inline SVG by decorateIcons() at end of decorate.
 // SVG sources live in /icons/<name>.svg.
@@ -142,14 +142,11 @@ export default function decorate(block) {
   const description = getMetadata('description');
   const tags = getMetadata('article:tag', true) || [];
 
-  // Borrow the h1 from <main>. The first picture has already been moved into
-  // the block by buildSessionHeader() in scripts.js (it has to happen there,
-  // before buildImageBlocks wraps the picture in an <images> block which our
-  // decorator would otherwise fail to find).
+  // Borrow the h1 from <main> so it doesn't render twice (the hero owns the
+  // title). Any pictures in the doc stay where the author put them in the
+  // body — the hero doesn't pull them in.
   const main = block.closest('main') || document.querySelector('main');
   const h1 = main.querySelector('h1');
-  const figureSlot = block.querySelector('.session-header-figure-slot');
-  const heroPicture = figureSlot ? figureSlot.querySelector('picture') : null;
 
   // Fall back to author when presenter wasn't filled in.
   const presenterText = meta.presenter || author || '';
@@ -196,23 +193,6 @@ export default function decorate(block) {
   );
 
   const hero = el('div', { class: 'session-header-hero' }, heroInner);
-
-  // ── Hero figure ──────────────────────────────────────────────────────
-  // The picture was moved into the block by buildSessionHeader() before
-  // buildImageBlocks could touch it, so it's just sitting in figureSlot.
-  // Build the right-side figure card from it and clean up the slot.
-  if (heroPicture) {
-    const img = heroPicture.querySelector('img');
-    if (img && img.src) {
-      const optimised = createOptimizedPicture(img.src, img.alt || '', true, [{ width: '750' }]);
-      const figure = document.createElement('figure');
-      figure.className = 'session-header-figure';
-      figure.append(optimised);
-      hero.append(figure);
-      hero.classList.add('has-figure');
-    }
-  }
-  if (figureSlot) figureSlot.remove();
 
   // ── Final assembly ────────────────────────────────────────────────────
   block.innerHTML = '';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -262,31 +262,14 @@ function buildImageBlocks(mainEl) {
  * @param {Element} main The container element
  */
 function buildSessionHeader(mainEl) {
-  // The actual hero (presenter, date, recording CTA, deck, Slack, figure
-  // image) is composed by blocks/session-header/session-header.js. We do
-  // two things here, BEFORE the rest of buildAutoBlocks runs:
-  //   1. Insert the session-header block placeholder at the top of <main>.
-  //   2. Move the first <picture>'s paragraph into the block as a slot.
-  //      We have to grab the picture here — buildImageBlocks runs later in
-  //      buildAutoBlocks and replaces <p><picture></p> with an <images>
-  //      block, which we don't want to touch. The decorator reads the
-  //      stashed picture from the block instead of re-querying <main>.
+  // Placeholder block — the actual hero (pills, title, description, meta
+  // row, CTAs) is composed by blocks/session-header/session-header.js,
+  // which reads page metadata directly. The hero deliberately does NOT
+  // include any picture; if the doc has pictures they flow inline in the
+  // body section like normal article content.
   const div = document.createElement('div');
-  const block = buildBlock('session-header', { elems: [] });
-  div.append(block);
+  div.append(buildBlock('session-header', { elems: [] }));
   mainEl.prepend(div);
-
-  const heroPicture = mainEl.querySelector('picture');
-  if (heroPicture) {
-    const wrapper = heroPicture.closest('p') || heroPicture.parentElement;
-    if (wrapper && wrapper !== mainEl) {
-      const slot = document.createElement('div');
-      slot.className = 'session-header-figure-slot';
-      slot.hidden = true;
-      slot.append(wrapper);
-      block.append(slot);
-    }
-  }
 }
 
 function buildAutoBlocks(main) {


### PR DESCRIPTION
## Summary

Follow-up to #94. PR #94 merged the wrong commit — the "extract picture earlier into a figure card" approach instead of the agreed-upon "drop the figure entirely" approach. This PR brings the simpler change to main.

After looking at the figure-card on a real session page, the verdict was: too much hero, too tall, picture trapped in a 320px box. The hero should end cleanly after the CTAs. Pictures in the doc just flow in the body section like normal article content.

## What changes

- `scripts.js` — `buildSessionHeader` is just `placeholder block` again (no picture stash, no figure slot).
- `session-header.js` — drop figureSlot lookup, figure card construction, `createOptimizedPicture` import.
- `session-header.css` — drop `.session-header-figure*` rules + `.has-figure` desktop overrides; reset hero bottom padding from 120px back to 64px.

Net: +14 / −114.

## Test URL

- After (this branch): https://refactor-aicoc-drop-figure--inside-aem--adobe.aem.live/en/aicoc/easymcp-desktop

## Test plan

- [ ] Hero ends after the CTA row (no figure card on right desktop, no stacked figure mobile)
- [ ] Picture in the doc renders normally below the hero (as an `<images>` block)
- [ ] Hero is shorter than before
- [ ] Hub card thumbnail still works (it's driven by `og:image` independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)