### PR TITLE
chore: touch scripts.js to force Helix redeploy

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,3 +1,5 @@
+// Touched 2026-06-08 to force a fresh Helix code deploy (CDN was stuck on the
+// pre-AI-CoC version of this file). No functional change.
 import {
   buildBlock,
   createOptimizedPicture,


### PR DESCRIPTION
Helix CDN is serving a pre-#93 version of scripts.js (28387 bytes — no aicoc loadCSS code) even after PRs #93, #94, #95 merged. The auto-deploy never picked up the new code, so the hub page's dark Adobe-red hero never renders even though body.aicoc-hub is set correctly.

This adds a header comment to scripts.js. No functional change. Merging it forces a fresh Helix code deploy, which should make the new aicoc loadCSS line actually go live.

After merge: hard refresh https://culture-tecture.adobe.com/en/aicochub and the dark hero should appear.