### PR TITLE
feat(aicoc): detect folder-URL decks and relabel CTA

### DIFF
--- a/blocks/session-header/session-header.js
+++ b/blocks/session-header/session-header.js
@@ -75,14 +75,40 @@ function buildRecording(url) {
   });
 }
 
+/**
+ * Heuristic: does this URL point to a SharePoint folder rather than a single
+ * file? Two patterns we care about:
+ *   - `:f:` share-link prefix (SharePoint's "Anyone with link can view" folder)
+ *   - Path-form URLs with no file extension after the last `/`
+ * Folders get a "Browse decks" label + folder icon since there's no single
+ * slide deck to download — the user needs to pick one inside the folder.
+ */
+function isFolderUrl(url) {
+  if (!url) return false;
+  if (/\/:f:\//i.test(url)) return true;
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split('/').filter(Boolean).pop() || '';
+    // Decode to handle %20 etc. — a folder name like "10-30-24 Show & Tell"
+    // has no dot in it.
+    const decoded = decodeURIComponent(last);
+    return !/\.[a-z0-9]{2,5}$/i.test(decoded);
+  } catch (_) {
+    return false;
+  }
+}
+
 function buildDeckButton(url) {
   if (!url) return null;
+  const folder = isFolderUrl(url);
+  const label = folder ? 'Browse decks' : 'Slides';
+  const iconName = folder ? 'folder' : 'download';
   return el('a', {
     class: 'btn btn-secondary',
     href: url,
     target: '_blank',
     rel: 'noopener',
-    html: `${icon('download')}<span>Slides</span>`,
+    html: `${icon(iconName)}<span>${label}</span>`,
   });
 }
 

--- a/icons/folder.svg
+++ b/icons/folder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+</svg>


### PR DESCRIPTION
## Summary

- When a session's Deck metadata cell points to a SharePoint folder (either a `:f:` share link or a path-form URL with no file extension), the session header now renders a **"Browse decks"** button with a folder icon instead of the default "Slides" + download icon
- Single-file deck URLs (.pdf, .pptx, .html, etc.) keep the original "Slides" + download icon — no behavior change for those
- Added `icons/folder.svg` matching the line-icon style of the other session-header CTAs

## Why

Several multi-presenter Show & Tell sessions have no single "primary" deck — each presenter brings their own. For those, the Deck metadata cell now holds the SharePoint folder URL so users can browse all the decks. The button label needs to honestly reflect that.

## Test plan

- [ ] Visit a session page where the Deck metadata points to a folder URL (e.g. `/en/aicoc/show-tell-october-30-2024`). Verify the button reads **"Browse decks"** with a folder icon.
- [ ] Visit a session page where the Deck metadata points to a `.pdf` (e.g. `/en/aicoc/ai-community-of-communities`). Verify the button still reads **"Slides"** with a download icon.
- [ ] Click both and confirm they open the correct SharePoint resource in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)