### PR TITLE
fix(dark-mode): article-card body stays white

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -753,6 +753,21 @@ main .section.carousel-container {
     background-color: #1e1e1e;
   }
 
+  /* `.article-card .article-card-body` hardcodes `background: var(--color-white)`
+   * in lazy-styles.css, so without an override here the inner body stays white
+   * while the outer card goes dark — and the title heading (which now inherits
+   * the light dark-mode body color) becomes light-on-white. Match the outer
+   * card so the title sits on its intended surface. */
+  .article-card .article-card-body {
+    background-color: #1e1e1e;
+  }
+
+  /* The default hover shadow (12% black) is invisible on dark backgrounds.
+   * Bump opacity and lift it to a brighter ring so the hover is still felt. */
+  main .article-feed .article-card:hover {
+    box-shadow: 0 4px 16px rgb(0 0 0 / 60%);
+  }
+
   .filter-dropdown {
     background: #1e1e1e;
     border-color: #2a2a2a;


### PR DESCRIPTION
## Summary

- `.article-card .article-card-body` hardcodes `background: var(--color-white)` in `lazy-styles.css`, so when the OS prefers dark mode, the outer `.article-card` flips to `#1e1e1e` but the inner body stays white. The h3 inside then inherits `--body-color` (`#e8e8e8` in dark mode) — light text on white, unreadable.
- Mirrors the existing `.article-card` dark-mode override onto `.article-card-body` so the title sits on its intended dark surface.
- Also bumps the hover shadow opacity — `rgb(0 0 0 / 12%)` is invisible on a dark background.

Light mode is unchanged. Change is fully contained inside the existing `@media (prefers-color-scheme: dark)` block in `styles/styles.css`.

## Test plan

- [ ] On a blog listing page (e.g. `/`, a tag page), toggle macOS / browser dark mode → titles + descriptions readable inside cards
- [ ] Toggle back to light mode → no visual diff
- [ ] Hover state on a card in dark mode is still felt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

- Dark mode test (toggle macOS/browser dark mode): [Blog index](https://fix-dark-mode-article-cards--inside-aem--adobe.aem.page/) · [AI tag page](https://fix-dark-mode-article-cards--inside-aem--adobe.aem.page/en/topics/ai)
- Light mode regression check: same URLs with system theme set to Light → cards look identical to production.

Branch preview host: `fix-dark-mode-article-cards--inside-aem--adobe.aem.page`
