### PR TITLE
feat(aicoc): move session title into the dark card header

### DIFF
--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -1,6 +1,10 @@
 /* AI CoC — session card.
  * Rendered inside session-feed. Self-contained styling so the card looks
  * right wherever it's placed, but assumes body.aicoc context for theme tone.
+ *
+ * Layout:
+ *   - .session-card-media  — dark area: gradient/image, format pill, title
+ *   - .session-card-body   — white area: description + presenter
  */
 
 .session-card {
@@ -23,35 +27,50 @@
   text-decoration: none;
 }
 
-/* ── media ────────────────────────────────────────────────────────────── */
+/* ── media (dark area) ─────────────────────────────────────────────────
+ * Holds the format pill (top-left), the session title (bottom-left), and
+ * an optional cover image with a gradient scrim for legibility.
+ */
 .session-card-media {
   position: relative;
   aspect-ratio: 16 / 9;
-  background: linear-gradient(135deg, #0b0b0d 0%, #1c0707 100%);
   overflow: hidden;
-}
-
-.session-card-media picture,
-.session-card-media img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.session-card-placeholder {
-  position: absolute;
-  inset: 0;
+  padding: 14px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   background:
     radial-gradient(600px 300px at 80% 20%, rgb(235 16 0 / 45%), transparent 60%),
     radial-gradient(500px 300px at 10% 90%, rgb(255 59 47 / 30%), transparent 60%),
     linear-gradient(135deg, #0b0b0d 0%, #1c0707 100%);
 }
 
-.session-card-format {
+/* When the session has its own cover image, the picture fills the media
+ * area underneath the title, and a dark scrim ensures the title stays
+ * readable regardless of the image's contrast. */
+.session-card-media-picture,
+.session-card-media-picture picture,
+.session-card-media-picture img {
   position: absolute;
-  top: 12px;
-  left: 12px;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  z-index: 0;
+}
+
+.session-card-media-scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgb(0 0 0 / 10%) 0%, rgb(0 0 0 / 65%) 100%);
+  z-index: 1;
+}
+
+.session-card-format {
+  position: relative;
+  z-index: 2;
+  align-self: flex-start;
   padding: 5px 12px;
   font-size: 11px;
   font-weight: 700;
@@ -60,8 +79,27 @@
   color: #fff;
   background: linear-gradient(90deg, rgb(235 16 0 / 95%), rgb(255 59 47 / 95%));
   border-radius: 999px;
-  z-index: 1;
   box-shadow: 0 4px 14px rgb(0 0 0 / 25%);
+  margin-bottom: auto;
+}
+
+.session-card-title {
+  position: relative;
+  z-index: 2;
+  margin: 16px 0 0;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: #fff;
+  text-shadow: 0 1px 12px rgb(0 0 0 / 40%);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.session-card:hover .session-card-title {
+  color: #fff;
 }
 
 .session-card-play {
@@ -72,6 +110,7 @@
   justify-content: center;
   pointer-events: none;
   opacity: 0;
+  z-index: 3;
   transition: opacity 0.2s ease;
 }
 
@@ -107,28 +146,17 @@
   transform: scale(1);
 }
 
-/* ── body ─────────────────────────────────────────────────────────────── */
+/* ── body (white area) ─────────────────────────────────────────────────
+ * Description + presenter. No title (in the media area) and no date (the
+ * feed is sorted chronologically, so the date doesn't earn its real estate
+ * inside the card).
+ */
 .session-card-body {
   padding: 16px 18px 18px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-
-.session-card-title {
-  font-size: 17px;
-  font-weight: 700;
-  line-height: 1.3;
-  color: #0b0b0d;
-  margin: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.session-card:hover .session-card-title {
-  color: #EB1000;
+  gap: 10px;
+  flex: 1;
 }
 
 .session-card-description {
@@ -137,26 +165,15 @@
   color: #4a4a4f;
   margin: 0;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
-.session-card-meta {
-  font-size: 13px;
-  color: #6e6e73;
-  margin: 0;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
 .session-card-presenter {
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: 600;
   color: #0b0b0d;
-}
-
-.session-card-sep {
-  color: #c5c5cd;
+  margin: 0;
+  margin-top: auto;
 }

--- a/blocks/session-card/session-card.js
+++ b/blocks/session-card/session-card.js
@@ -7,6 +7,18 @@ import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
  * Pattern mirrors `buildArticleCard` in scripts.js — returns DOM directly so
  * the feed block can paginate cheaply without redecorating.
  *
+ * Layout:
+ *   ┌──────────────────────────────┐
+ *   │ [AI COC]                     │  ← dark media area (gradient or image)
+ *   │                              │     holds the format pill (top-left)
+ *   │                              │     and the session TITLE (bottom)
+ *   │  Session title goes here     │
+ *   ├──────────────────────────────┤
+ *   │ Short description text…      │  ← white body holds the description
+ *   │                              │     and the presenter name(s).
+ *   │ Presenter Names              │
+ *   └──────────────────────────────┘
+ *
  * @param {Object} session — one row from the index (already-typed by parseSessions in session-feed)
  * @param {boolean} eager — pass true for above-the-fold cards so the picture isn't lazy
  * @returns {HTMLAnchorElement}
@@ -18,7 +30,6 @@ export function buildSessionCard(session, eager = false) {
     description,
     image,
     imageAlt,
-    sessionDate,
     presenter,
     tags = [],
   } = session;
@@ -27,22 +38,26 @@ export function buildSessionCard(session, eager = false) {
   card.className = 'session-card';
   card.href = path;
 
-  // ── media ─────────────────────────────────────────────────────────────
+  // ── media (dark area) ────────────────────────────────────────────────
+  // Holds: optional cover image, format pill, session title, play overlay.
   const media = document.createElement('div');
   media.className = 'session-card-media';
 
   if (image) {
     const picture = createOptimizedPicture(image, imageAlt || title, eager, [{ width: '600' }]);
+    picture.classList.add('session-card-media-picture');
     media.append(picture);
+    // Gradient overlay so the title stays legible over any image.
+    const scrim = document.createElement('div');
+    scrim.className = 'session-card-media-scrim';
+    scrim.setAttribute('aria-hidden', 'true');
+    media.append(scrim);
   } else {
-    // Visual placeholder so cards line up even without a hero image.
-    const placeholder = document.createElement('div');
-    placeholder.className = 'session-card-placeholder';
-    placeholder.setAttribute('aria-hidden', 'true');
-    media.append(placeholder);
+    // No image — the gradient placeholder is provided by .session-card-media's
+    // own background, so there's nothing to inject here.
   }
 
-  // Format badge (first tag — e.g. "Brownbag", "Deep Dive").
+  // Format badge (first tag — e.g. "Brownbag", "Show & Tell").
   const format = tags[0];
   if (format) {
     const badge = document.createElement('span');
@@ -51,7 +66,14 @@ export function buildSessionCard(session, eager = false) {
     media.append(badge);
   }
 
-  // Play-button overlay so the recording affordance is visible.
+  // Title lives inside the dark area now — the white body below is for the
+  // description and presenter only.
+  const titleEl = document.createElement('h3');
+  titleEl.className = 'session-card-title';
+  titleEl.textContent = title || '';
+  media.append(titleEl);
+
+  // Play-button overlay so the recording affordance is visible on hover.
   // The inner <span class="icon icon-play"> is swapped for the inline SVG by
   // decorateIcons() in session-feed.js after the card is appended.
   media.insertAdjacentHTML(
@@ -59,14 +81,11 @@ export function buildSessionCard(session, eager = false) {
     '<span class="session-card-play" aria-hidden="true"><span class="icon icon-play"></span></span>',
   );
 
-  // ── body ──────────────────────────────────────────────────────────────
+  // ── body (white area) ────────────────────────────────────────────────
+  // Description + presenter only. No title (in the dark area above) and no
+  // date (already encoded in the chronological order of the feed).
   const body = document.createElement('div');
   body.className = 'session-card-body';
-
-  const titleEl = document.createElement('h3');
-  titleEl.className = 'session-card-title';
-  titleEl.textContent = title || '';
-  body.append(titleEl);
 
   if (description) {
     const descEl = document.createElement('p');
@@ -75,13 +94,12 @@ export function buildSessionCard(session, eager = false) {
     body.append(descEl);
   }
 
-  const meta = document.createElement('p');
-  meta.className = 'session-card-meta';
-  const parts = [];
-  if (sessionDate) parts.push(`<span class="session-card-date">${sessionDate}</span>`);
-  if (presenter) parts.push(`<span class="session-card-presenter">${presenter}</span>`);
-  meta.innerHTML = parts.join('<span class="session-card-sep">·</span>');
-  body.append(meta);
+  if (presenter) {
+    const presEl = document.createElement('p');
+    presEl.className = 'session-card-presenter';
+    presEl.textContent = presenter;
+    body.append(presEl);
+  }
 
   card.append(media, body);
   return card;


### PR DESCRIPTION
## Summary

The dark area at the top of each session card on `/en/aicochub` was empty visual padding — just a gradient and a format pill. Title + presenter were crammed into the white body, and the description was nowhere to be seen.

This PR rebalances the card:

- **Dark area** — format pill (top-left) + session **title** (bottom-left), white-on-dark with a soft text-shadow so the title stays readable over any cover image.
- **White body** — **description** (up to 4 lines, previously hidden) + **presenter** (bottom-aligned).
- **Date** was removed from the card. The feed sorts chronologically so the date doesn't earn its space here; the full date is still on the session detail page.

The play-icon overlay still appears on hover, layered above the title via `z-index`. When a session has a cover image, a dark scrim ensures the title stays legible regardless of image contrast.

## Test plan

- [ ] Open `/en/aicochub` → cards show title on the dark band, description + presenter on the white band
- [ ] Hover a card → play icon overlays centered, border + shadow shift to red
- [ ] Sessions without a description still render correctly (no empty body)
- [ ] Sessions with a cover image (if any are uploaded) still show the image with title overlaid via the gradient scrim
- [ ] Mobile width — title doesn't overflow the dark area

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

- [/en/aicochub on this branch](https://feat-aicoc-card-redesign--inside-aem--adobe.aem.page/en/aicochub) — see the new card layout (title in dark header, description + presenter in white body)
- A session page (unchanged by this PR but useful for sanity): [meet-fluffyjaws](https://feat-aicoc-card-redesign--inside-aem--adobe.aem.page/en/aicoc/meet-fluffyjaws-revolutionizing-adobe-internal-support-with-domain-savvy-ai)

Branch preview host: `feat-aicoc-card-redesign--inside-aem--adobe.aem.page`

Hover behavior is intentional — title in the dark area, play icon overlays on hover via z-index. If you'd rather keep the date on the card, say the word.
