### PR TITLE
feat(aicoc): add Read blog CTA to session header

### DIFF
--- a/blocks/session-header/session-header.js
+++ b/blocks/session-header/session-header.js
@@ -126,6 +126,22 @@ function buildSlackButton(slack) {
   });
 }
 
+/**
+ * "Read blog" CTA — points to the matching post on culture-tecture.adobe.com
+ * (or wherever the author put the canonical write-up). Opens in a new tab
+ * since most of these are off-domain on re-think.adobe.com.
+ */
+function buildBlogButton(url) {
+  if (!url) return null;
+  return el('a', {
+    class: 'btn btn-secondary',
+    href: url,
+    target: '_blank',
+    rel: 'noopener',
+    html: `${icon('book-open')}<span>Read blog</span>`,
+  });
+}
+
 function buildPresenters(presenterStr) {
   const presenters = splitCommaList(presenterStr);
   if (!presenters.length) return null;
@@ -162,6 +178,7 @@ export default function decorate(block) {
     sessionDate: getMetadata('session-date'),
     recording: getMetadata('recording'),
     deck: getMetadata('deck'),
+    blog: getMetadata('blog'),
     slack: getMetadata('slack'),
   };
   const author = getMetadata('author');
@@ -199,11 +216,14 @@ export default function decorate(block) {
   if (presenters) metaRow.append(presenters);
 
   // CTAs.
+  // Order: Watch recording (primary) → Slides/Browse decks → Read blog → Slack.
   const ctaRow = el('div', { class: 'session-header-ctas' });
   const watch = buildRecording(meta.recording);
   if (watch) ctaRow.append(watch);
   const deck = buildDeckButton(meta.deck);
   if (deck) ctaRow.append(deck);
+  const blog = buildBlogButton(meta.blog);
+  if (blog) ctaRow.append(blog);
   const slack = buildSlackButton(meta.slack);
   if (slack) ctaRow.append(slack);
 

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -80,6 +80,10 @@ indices:
         select: head > meta[name="deck"]
         value: |
           attribute(el, 'content')
+      blog:
+        select: head > meta[name="blog"]
+        value: |
+          attribute(el, 'content')
       slack:
         select: head > meta[name="slack"]
         value: |

--- a/icons/book-open.svg
+++ b/icons/book-open.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2 4h7a3 3 0 0 1 3 3v13a2 2 0 0 0-2-2H2z"/>
+  <path d="M22 4h-7a3 3 0 0 0-3 3v13a2 2 0 0 1 2-2h8z"/>
+</svg>


### PR DESCRIPTION
## Summary

Surfaces a fourth CTA in the AI CoC session hero — **Read blog** — pointing at the matching post on culture-tecture.adobe.com (or re-think.adobe.com). For sessions where the presenter also wrote the canonical write-up, this turns the hub from a recording-only archive into a launchpad for both formats.

- New `blog` metadata field, indexed by `helix-query.yaml` into `/en/aicoc-index.json`.
- `buildBlogButton(url)` in `session-header.js` renders only when the cell is populated (same pattern as Recording / Deck / Slack — no per-doc code change).
- New `icons/book-open.svg`.
- CTA order: **Watch recording → Slides → Read blog → Slack**.

## Required follow-up in SharePoint

Per-session: add a `Blog` row to the Metadata table (between Deck and Slack), value = the bare blog URL. 8 high-confidence matches identified from `#ai-community-of-communities` recap mining — list will be applied to the local docx files in a separate pass.

## Test plan

- [ ] On a session page with a `blog` cell, the "Read blog" button appears between "Slides" and Slack
- [ ] On a session page without a `blog` cell, no button appears (no regression vs. today)
- [ ] Button opens the blog URL in a new tab
- [ ] Light + dark mode both readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview

**Without re-uploading docs:** the button only renders when a session page has a `blog` metadata cell. Existing published pages won't have that yet, so the preview branch alone will look identical to production.

**To actually see the button:** re-upload one of the patched docs in `~/Downloads/aicocdocs/` (the 11 with a populated Blog cell) to SharePoint, preview/publish that one page, then visit it on this branch:

- [meet-fluffyjaws](https://feat-aicoc-blog-cta--inside-aem--adobe.aem.page/en/aicoc/meet-fluffyjaws-revolutionizing-adobe-internal-support-with-domain-savvy-ai) — should show "Read blog" between Slides and Slack once the doc is re-published
- [agents-skills-harness-engineering](https://feat-aicoc-blog-cta--inside-aem--adobe.aem.page/en/aicoc/agents-skills-harness-engineering-and-other-buzz-words)
- [the-ai-fluency-sprint-model](https://feat-aicoc-blog-cta--inside-aem--adobe.aem.page/en/aicoc/the-ai-fluency-sprint-model)

Branch preview host: `feat-aicoc-blog-cta--inside-aem--adobe.aem.page`

**No-regression check (no blog cell):** any session without a Blog row should look exactly like main. Pick any session not in the 11-doc list above.
