### PR TITLE
fix(aicoc-session): skip buildHeroBlock on session pages

### DIFF
--- a/blocks/session-header/session-header.css
+++ b/blocks/session-header/session-header.css
@@ -18,10 +18,16 @@ main .session-header {
 }
 
 /* ── HERO ─────────────────────────────────────────────────────────────── */
+/* Contained, rounded hero — matches the /aicochub landing hero: a centred
+ * dark block with the page background showing on either side, rather than
+ * a full-bleed edge-to-edge band. */
 .session-header-hero {
   position: relative;
   overflow: hidden;
+  max-width: 1200px;
+  margin: 32px auto 0;
   padding: 64px 32px 56px;
+  border-radius: 24px;
   color: #fff;
   background:
     radial-gradient(1100px 520px at 88% -10%, rgb(235 16 0 / 55%), transparent 62%),

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -277,12 +277,12 @@ function buildSessionHeader(mainEl) {
 function buildAutoBlocks(main) {
   removeStylingFromImages(main);
   try {
-    buildHeroBlock(main);
     // AI CoC session pages get a custom hero; the regular article header would
     // misrepresent the metadata, so route to buildSessionHeader instead.
     // Opt-in is driven by `Theme: aicoc, aicoc-session` in doc metadata —
     // decorateTemplateAndTheme() in loadEager has already set the body class.
     const isAicocSession = document.body.classList.contains('aicoc-session');
+    if (!isAicocSession) buildHeroBlock(main);
     if (isAicocSession) {
       if (getMetadata('publication-date') && !main.querySelector('.session-header')) {
         buildSessionHeader(main);


### PR DESCRIPTION
## Summary

- `buildHeroBlock` was running unconditionally before the `aicoc-session` check, prepending a spurious `hero` block on session pages
- This caused the blog layout to take over even when `Theme: aicoc, aicoc-session` was set in the document metadata
- Fix: guard `buildHeroBlock` behind `!isAicocSession`

## Test plan

- [x] [Preview the fixed page](https://fix-dark-mode-session-card--inside-aem--adobe.aem.page/en/aicoc/ai-community-of-communities) — should show dark session hero, not blog layout
- [x] Verify a regular blog post still renders correctly (hero block unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)