### PR TITLE
fix(aicoc-session): improve breadcrumb legibility on dark hero

### DIFF
--- a/blocks/session-header/session-header.css
+++ b/blocks/session-header/session-header.css
@@ -18,6 +18,7 @@ main .session-header {
 }
 
 /* ── HERO ─────────────────────────────────────────────────────────────── */
+
 /* Contained, rounded hero — matches the /aicochub landing hero: a centred
  * dark block with the page background showing on either side, rather than
  * a full-bleed edge-to-edge band. */
@@ -57,26 +58,32 @@ main .session-header {
   margin: 0 auto;
 }
 
-/* breadcrumb */
+/* breadcrumb
+ * Explicit colours (no stacked opacity) so it stays legible on the dark
+ * hero. The link colour is set with extra specificity to beat the theme's
+ * `body.aicoc main a` red rule. */
 .session-header-breadcrumb {
   font-size: 13px;
   letter-spacing: 0.04em;
-  opacity: 0.75;
   display: flex;
   align-items: center;
   gap: 10px;
   margin-bottom: 20px;
 }
 
-.session-header-breadcrumb a {
-  color: #fff;
-  opacity: 0.85;
+body.aicoc-session .session-header-breadcrumb a {
+  color: #ff6a5e;
+  opacity: 1;
   text-decoration: none;
 }
 
-.session-header-breadcrumb a:hover { text-decoration: underline; }
-.session-header-breadcrumb-sep { opacity: 0.35; }
-.session-header-breadcrumb-current { opacity: 0.6; }
+body.aicoc-session .session-header-breadcrumb a:hover {
+  color: #ff8a80;
+  text-decoration: underline;
+}
+
+.session-header-breadcrumb-sep { color: rgb(255 255 255 / 45%); }
+.session-header-breadcrumb-current { color: rgb(255 255 255 / 80%); }
 
 /* pills */
 .session-header-pills {


### PR DESCRIPTION
## Summary

The breadcrumb on session pages (e.g. *AI CoC Hub › Oct 17, 2024*) was hard to read on the dark hero:
- Stacked `opacity` (0.75 on the nav × 0.6 on the current date) made the date nearly invisible.
- The "AI CoC Hub" link picked up the theme's red `body.aicoc main a` colour and was further dimmed by the nav opacity.

Replaces the stacked opacity with explicit high-contrast colours:
- Link: brighter coral (`#ff6a5e`), full opacity, set with extra specificity to beat the theme rule; brighter on hover.
- Separator: `rgb(255 255 255 / 45%)`.
- Current page label: `rgb(255 255 255 / 80%)`.

Also removes a duplicate `.session-header-breadcrumb-current { opacity: 0.6 }` rule.

## Test plan
- [x] [Session page](https://fix-session-breadcrumb-contrast--inside-aem--adobe.aem.page/en/aicoc/ai-community-of-communities) — breadcrumb link + date are clearly legible on the dark hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)