### PR TITLE
fix: prevent inline code from overflowing its container

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -186,8 +186,9 @@ code, pre, samp {
 
 code, samp {
   background-color: var(--overlay-background-color);
-  padding: 1em;
+  padding: .125em .375em;
   border-radius: .25em;
+  word-break: break-word;
 }
 
 pre code, pre samp {


### PR DESCRIPTION
## Summary
- Reduced inline `code`/`samp` padding from `1em` to `.125em .375em` — the large padding with a monospace font was making elements overly wide
- Added `word-break: break-word` so long strings wrap instead of running outside their parent container

## Test plan
- [ ] Check a page with inline code elements using Courier New / monospace font
- [ ] Verify long inline code strings wrap within their container
- [ ] Verify `pre code` blocks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)