### PR TITLE
fix: fix inline code overflow with break-all and overflow-wrap

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -188,7 +188,8 @@ code, samp {
   background-color: var(--overlay-background-color);
   padding: .125em .375em;
   border-radius: .25em;
-  word-break: break-word;
+  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 pre code, pre samp {


### PR DESCRIPTION
## Summary
- Replaces `word-break: break-word` (only breaks at word boundaries) with `word-break: break-all` so text wraps at any character
- Adds `overflow-wrap: break-word` as a complementary rule to handle all overflow cases

The previous fix didn't fully solve the issue because `break-word` only kicks in when there are no other break opportunities. `break-all` forces wrapping at any character regardless.

## Test plan
- [ ] Verify inline code with long text (with and without spaces) wraps within its container
- [ ] Verify `pre code` blocks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)