### PR TITLE
fix: wrap pre blocks with pre-wrap to prevent horizontal overflow

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -207,7 +207,8 @@ main pre {
   padding: 1em;
   border-radius: .25em;
   overflow-x: auto;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 a:any-link {


### PR DESCRIPTION
## Summary
- Changes `white-space: pre` to `pre-wrap` on `main pre` so code blocks wrap within their container instead of scrolling horizontally
- Adds `word-break: break-all` so long unbroken strings also wrap

## Test plan
- [ ] Verify code blocks with long lines wrap within the container
- [ ] Verify indentation and line breaks in code blocks are still preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)