### PR TITLE
feat: blue style variant for AI Assisted Brownbag sessions

### DIFF
--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -210,6 +210,29 @@
 }
 /* stylelint-enable selector-class-pattern, no-descending-specificity */
 
+/* ── Brownbag variant (blue) ──────────────────────────────────────────────
+ * AI Assisted Brownbag sessions get a blue gradient instead of red.
+ * Only the media background, format badge, and hover accent change.
+ */
+/* stylelint-disable selector-class-pattern */
+.session-card--brownbag .session-card-media {
+  background:
+    radial-gradient(600px 300px at 80% 20%, rgb(2 101 220 / 45%), transparent 60%),
+    radial-gradient(500px 300px at 10% 90%, rgb(55 142 240 / 30%), transparent 60%),
+    linear-gradient(135deg, #0b0b0d 0%, #06101c 100%);
+}
+
+.session-card--brownbag .session-card-format {
+  background: linear-gradient(90deg, rgb(2 101 220 / 95%), rgb(55 142 240 / 95%));
+}
+
+.session-card--brownbag:hover,
+.session-card--brownbag:focus-visible {
+  border-color: #0265DC;
+  box-shadow: 0 8px 24px rgb(2 101 220 / 12%);
+}
+/* stylelint-enable selector-class-pattern */
+
 /* ── Dark mode ────────────────────────────────────────────────────────────
  * The AI CoC hub is intentionally dark-themed even in light mode (red
  * gradient hero), so a bright white card body sitting on a near-black page

--- a/blocks/session-card/session-card.js
+++ b/blocks/session-card/session-card.js
@@ -64,6 +64,7 @@ export function buildSessionCard(session, eager = false) {
   // Tag image-less cards so the CSS can collapse the empty 16:9 media area
   // to a compact pill strip — otherwise it's just dead space above the title.
   if (!image) card.classList.add('session-card--no-image');
+  if (tags[0] && /brownbag/i.test(tags[0])) card.classList.add('session-card--brownbag');
   card.href = path;
 
   // ── media (dark area) ────────────────────────────────────────────────

--- a/blocks/session-header/session-header.css
+++ b/blocks/session-header/session-header.css
@@ -246,3 +246,31 @@ main .session-header .btn-tertiary {
     padding: 80px 48px 64px;
   }
 }
+
+/* ── Brownbag variant (blue) ──────────────────────────────────────────────
+ * AI Assisted Brownbag sessions get a blue gradient hero instead of red.
+ */
+/* stylelint-disable selector-class-pattern */
+.session-header-hero--brownbag {
+  background:
+    radial-gradient(1100px 520px at 88% -10%, rgb(2 101 220 / 55%), transparent 62%),
+    radial-gradient(900px 600px at -8% 115%, rgb(55 142 240 / 35%), transparent 60%),
+    linear-gradient(135deg, #0b0b0d 0%, #060e1a 55%, #06101c 100%);
+}
+
+.session-header-hero--brownbag .session-header-pill-format {
+  background: linear-gradient(90deg, rgb(2 101 220 / 95%), rgb(55 142 240 / 95%));
+}
+
+.session-header-hero--brownbag .session-header-breadcrumb a {
+  color: #6db3f2;
+}
+
+.session-header-hero--brownbag .session-header-breadcrumb a:hover {
+  color: #9ecef7;
+}
+
+.session-header-hero--brownbag .session-header-presenter-avatar {
+  background: linear-gradient(135deg, #0054B6, #0265DC);
+}
+/* stylelint-enable selector-class-pattern */

--- a/blocks/session-header/session-header.js
+++ b/blocks/session-header/session-header.js
@@ -239,6 +239,7 @@ export default function decorate(block) {
   );
 
   const hero = el('div', { class: 'session-header-hero' }, heroInner);
+  if (tags[0] && /brownbag/i.test(tags[0])) hero.classList.add('session-header-hero--brownbag');
 
   // ── Final assembly ────────────────────────────────────────────────────
   block.innerHTML = '';


### PR DESCRIPTION
## Summary
- Brownbag session cards get a **blue gradient** on the tile (media area, format badge, hover accent) instead of red
- Brownbag session header heroes get a **blue gradient** background, blue format pill, blue breadcrumb links, and blue presenter avatars
- Show & Tell sessions are **completely unchanged**
- Detection is based on the first tag containing "brownbag" (case-insensitive), matching values like "AI Assisted Brownbag"

## Files changed
- `blocks/session-card/session-card.js` — adds `session-card--brownbag` class
- `blocks/session-card/session-card.css` — blue overrides for brownbag cards
- `blocks/session-header/session-header.js` — adds `session-header-hero--brownbag` class
- `blocks/session-header/session-header.css` — blue overrides for brownbag hero

## Test plan
- [ ] Hub page (`/en/aicochub`): Brownbag cards show blue gradient, Show & Tell cards remain red
- [ ] Brownbag session page: hero background is blue, format pill is blue
- [ ] Show & Tell session page: no visual change

## Preview
`https://feat-brownbag-blue-style--inside-aem--adobe.aem.page/en/aicochub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)