### PR TITLE
fix: detect brownbag format from page title instead of tags

### DIFF
--- a/blocks/session-card/session-card.js
+++ b/blocks/session-card/session-card.js
@@ -64,7 +64,7 @@ export function buildSessionCard(session, eager = false) {
   // Tag image-less cards so the CSS can collapse the empty 16:9 media area
   // to a compact pill strip — otherwise it's just dead space above the title.
   if (!image) card.classList.add('session-card--no-image');
-  if (tags[0] && /brownbag/i.test(tags[0])) card.classList.add('session-card--brownbag');
+  if (/brownbag/i.test(title)) card.classList.add('session-card--brownbag');
   card.href = path;
 
   // ── media (dark area) ────────────────────────────────────────────────

--- a/blocks/session-header/session-header.js
+++ b/blocks/session-header/session-header.js
@@ -239,7 +239,7 @@ export default function decorate(block) {
   );
 
   const hero = el('div', { class: 'session-header-hero' }, heroInner);
-  if (tags[0] && /brownbag/i.test(tags[0])) hero.classList.add('session-header-hero--brownbag');
+  if (/brownbag/i.test(document.title)) hero.classList.add('session-header-hero--brownbag');
 
   // ── Final assembly ────────────────────────────────────────────────────
   block.innerHTML = '';


### PR DESCRIPTION
## Summary
Fixes the brownbag blue style not appearing after merging PR #109.

The `article:tag` metadata only contains `"AI CoC"` — the format type ("AI Assisted Brownbag" vs "Show & Tell") is encoded in the page title. Switched detection from `tags[0]` to a regex match against `title` (cards) and `document.title` (session header).

## Test plan
- [ ] Hub page: Brownbag session cards show blue gradient
- [ ] Brownbag session page: hero background is blue
- [ ] Show & Tell session page: no change

## Preview
`https://feat-brownbag-blue-style--inside-aem--adobe.aem.page/en/aicochub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)