### PR TITLE
feat: polish hub page — tighter hero, lighter cards, dot pattern

### DIFF
--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -10,7 +10,7 @@
 .session-card {
   display: flex;
   flex-direction: column;
-  background: #fff;
+  background: #f5f5f7;
   border: 1px solid #e5e5e7;
   border-radius: 12px;
   overflow: hidden;
@@ -75,15 +75,15 @@
   position: relative;
   z-index: 2;
   align-self: flex-start;
-  padding: 5px 12px;
-  font-size: 11px;
+  padding: 3px 10px;
+  font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #fff;
-  background: linear-gradient(90deg, rgb(235 16 0 / 95%), rgb(255 59 47 / 95%));
+  color: rgb(255 255 255 / 90%);
+  background: linear-gradient(90deg, rgb(235 16 0 / 80%), rgb(255 59 47 / 80%));
   border-radius: 999px;
-  box-shadow: 0 4px 14px rgb(0 0 0 / 25%);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
   margin-bottom: auto;
 }
 
@@ -208,6 +208,18 @@
 .session-card--no-image .session-card-play {
   display: none;
 }
+
+.session-card--no-image .session-card-media::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgb(255 255 255 / 6%) 0 1px, transparent 1px),
+    radial-gradient(circle at 70% 80%, rgb(255 255 255 / 5%) 0 1px, transparent 1px),
+    radial-gradient(circle at 90% 20%, rgb(255 255 255 / 5%) 0 1px, transparent 1px);
+  background-size: 40px 40px, 30px 30px, 60px 60px;
+  pointer-events: none;
+}
 /* stylelint-enable selector-class-pattern, no-descending-specificity */
 
 /* ── Brownbag variant (blue) ──────────────────────────────────────────────
@@ -223,7 +235,7 @@
 }
 
 .session-card--brownbag .session-card-format {
-  background: linear-gradient(90deg, rgb(2 101 220 / 95%), rgb(55 142 240 / 95%));
+  background: linear-gradient(90deg, rgb(2 101 220 / 80%), rgb(55 142 240 / 80%));
 }
 
 .session-card--brownbag:hover,

--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -89,7 +89,7 @@ body.aicoc-hub main > div:first-of-type {
    * around a centered dark block, instead of dark edge-to-edge. */
   max-width: 1200px;
   margin: 32px auto 0;
-  padding: 64px 32px 56px;
+  padding: 40px 32px 36px;
   border-radius: 24px;
   color: #fff;
   text-align: center;


### PR DESCRIPTION
## Summary
Four visual polish changes to the AI CoC hub page:

1. **Tighter hero** — top padding reduced from 64px → 40px, bottom from 56px → 36px
2. **Subtler format badge** — smaller (11px/5px → 10px/3px padding), opacity reduced from 95% → 80%  
3. **Off-white card body** — `#fff` → `#f5f5f7` softens the harsh contrast against the dark page background
4. **Dot pattern on no-image cards** — subtle radial dot texture on the dark media area of cards without a cover image, matching the style used on the hero

## Preview
`https://feat-hub-polish--inside-aem--adobe.aem.page/en/aicochub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)