### PR TITLE
fix: collapse hidden hr section causing large gap below hub hero

### DIFF
--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -168,6 +168,11 @@ body.aicoc-hub main hr {
   display: none;
 }
 
+body.aicoc-hub main > div:has(> hr) {
+  margin: 0;
+  padding: 0;
+}
+
 /* Any section in main BEYOND the first one (where the session-feed sits).
  * Constrained to match the hero width, with the page bg showing on either
  * side. */


### PR DESCRIPTION
## Summary
The `---` divider in the Word doc creates an `<hr>` wrapped in its own EDS section `<div>`, which was getting the default boilerplate margin even though the `<hr>` itself was hidden. Added `:has(> hr)` rule to zero out that section's margin and padding.

## Preview
`https://feat-hub-polish--inside-aem--adobe.aem.page/en/aicochub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)