### PR TITLE
feat: refresh AI CoC design — navy base, gradient text, frosted badges

### DIFF
--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -45,8 +45,8 @@
   justify-content: flex-end;
   background:
     radial-gradient(600px 300px at 80% 20%, rgb(235 16 0 / 45%), transparent 60%),
-    radial-gradient(500px 300px at 10% 90%, rgb(255 59 47 / 30%), transparent 60%),
-    linear-gradient(135deg, #0b0b0d 0%, #1c0707 100%);
+    radial-gradient(400px 300px at 10% 90%, rgb(99 60 255 / 20%), transparent 60%),
+    linear-gradient(135deg, #080d1a 0%, #120609 100%);
 }
 
 /* When the session has its own cover image, the picture fills the media
@@ -80,10 +80,11 @@
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgb(255 255 255 / 90%);
-  background: linear-gradient(90deg, rgb(235 16 0 / 80%), rgb(255 59 47 / 80%));
+  color: rgb(255 160 150 / 95%);
+  background: rgb(235 16 0 / 18%);
+  border: 1px solid rgb(235 16 0 / 35%);
   border-radius: 999px;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
+  box-shadow: none;
   margin-bottom: auto;
 }
 
@@ -230,12 +231,14 @@
 .session-card--brownbag .session-card-media {
   background:
     radial-gradient(600px 300px at 80% 20%, rgb(2 101 220 / 45%), transparent 60%),
-    radial-gradient(500px 300px at 10% 90%, rgb(55 142 240 / 30%), transparent 60%),
-    linear-gradient(135deg, #0b0b0d 0%, #06101c 100%);
+    radial-gradient(400px 300px at 10% 90%, rgb(99 60 255 / 20%), transparent 60%),
+    linear-gradient(135deg, #080d1a 0%, #060e1a 100%);
 }
 
 .session-card--brownbag .session-card-format {
-  background: linear-gradient(90deg, rgb(2 101 220 / 80%), rgb(55 142 240 / 80%));
+  background: rgb(2 101 220 / 18%);
+  border: 1px solid rgb(2 101 220 / 35%);
+  color: rgb(100 180 250 / 95%);
 }
 
 .session-card--brownbag:hover,
@@ -255,11 +258,8 @@
  */
 @media (prefers-color-scheme: dark) {
   .session-card {
-    /* Lighter than the page bg (#0b0b0d) so cards lift visibly. The
-     * earlier #1a1a1c was too close to the page tone and the cards
-     * blended in. */
-    background: #2d2d33;
-    border-color: #3d3d44;
+    background: #0d1325;
+    border-color: rgb(255 255 255 / 8%);
   }
 
   .session-card:hover,

--- a/blocks/session-header/session-header.css
+++ b/blocks/session-header/session-header.css
@@ -31,9 +31,9 @@ main .session-header {
   border-radius: 24px;
   color: #fff;
   background:
-    radial-gradient(1100px 520px at 88% -10%, rgb(235 16 0 / 55%), transparent 62%),
-    radial-gradient(900px 600px at -8% 115%, rgb(255 59 47 / 35%), transparent 60%),
-    linear-gradient(135deg, #0b0b0d 0%, #141416 55%, #1c0707 100%);
+    radial-gradient(1100px 520px at 88% -10%, rgb(235 16 0 / 50%), transparent 62%),
+    radial-gradient(700px 500px at -8% 115%, rgb(99 60 255 / 22%), transparent 60%),
+    linear-gradient(135deg, #080d1a 0%, #100818 55%, #160609 100%);
 }
 
 .session-header-hero::before {
@@ -107,8 +107,9 @@ body.aicoc-session .session-header-breadcrumb a:hover {
 }
 
 .session-header-pill-format {
-  background: linear-gradient(90deg, rgb(235 16 0 / 95%), rgb(255 59 47 / 95%));
-  border-color: transparent;
+  background: rgb(235 16 0 / 18%);
+  border-color: rgb(235 16 0 / 35%);
+  color: rgb(255 150 140 / 95%);
 }
 
 /* title */
@@ -184,7 +185,8 @@ main .session-header h1.session-header-title {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #B30C00, #EB1000);
+  background: rgb(235 16 0 / 25%);
+  border-color: rgb(235 16 0 / 35%);
   color: #fff;
   font-size: 11px;
   font-weight: 700;
@@ -253,13 +255,15 @@ main .session-header .btn-tertiary {
 /* stylelint-disable selector-class-pattern */
 .session-header-hero--brownbag {
   background:
-    radial-gradient(1100px 520px at 88% -10%, rgb(2 101 220 / 55%), transparent 62%),
-    radial-gradient(900px 600px at -8% 115%, rgb(55 142 240 / 35%), transparent 60%),
-    linear-gradient(135deg, #0b0b0d 0%, #060e1a 55%, #06101c 100%);
+    radial-gradient(1100px 520px at 88% -10%, rgb(2 101 220 / 50%), transparent 62%),
+    radial-gradient(700px 500px at -8% 115%, rgb(99 60 255 / 22%), transparent 60%),
+    linear-gradient(135deg, #080d1a 0%, #060d1a 55%, #071426 100%);
 }
 
 .session-header-hero--brownbag .session-header-pill-format {
-  background: linear-gradient(90deg, rgb(2 101 220 / 95%), rgb(55 142 240 / 95%));
+  background: rgb(2 101 220 / 18%);
+  border-color: rgb(2 101 220 / 35%);
+  color: rgb(100 180 250 / 95%);
 }
 
 .session-header-hero--brownbag .session-header-breadcrumb a {

--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -20,12 +20,15 @@ body.aicoc {
   --aicoc-accent-1: #EB1000;   /* Adobe red */
   --aicoc-accent-2: #FF3B2F;   /* coral, for gradients */
   --aicoc-accent-3: #B30C00;   /* deep red, for hover/pressed */
+  --aicoc-blue-1: #0265DC;
+  --aicoc-purple-1: #633CFF;
   --aicoc-ink: #0b0b0d;
   --aicoc-ink-2: #2c2c2e;
   --aicoc-muted: #6e6e73;
   --aicoc-border: #e5e5e7;
   --aicoc-bg: #fafafa;
   --aicoc-card: #fff;
+  --aicoc-dark-base: #080d1a;
 
   background-color: var(--aicoc-bg);
   color: var(--aicoc-ink);
@@ -94,9 +97,10 @@ body.aicoc-hub main > div:first-of-type {
   color: #fff;
   text-align: center;
   background:
-    radial-gradient(1100px 520px at 88% -10%, rgb(235 16 0 / 55%), transparent 62%),
-    radial-gradient(900px 600px at -8% 115%, rgb(255 59 47 / 35%), transparent 60%),
-    linear-gradient(to bottom, #0b0b0d 0%, #150506 100%);
+    radial-gradient(ellipse 900px 500px at 15% -20%, rgb(99 60 255 / 20%), transparent 65%),
+    radial-gradient(ellipse 700px 500px at 90% 120%, rgb(2 101 220 / 16%), transparent 60%),
+    radial-gradient(ellipse 600px 400px at 88% -10%, rgb(235 16 0 / 35%), transparent 55%),
+    linear-gradient(to bottom, #080d1a 0%, #0c0912 100%);
 }
 
 body.aicoc-hub main > div:first-of-type::before {
@@ -126,21 +130,27 @@ body.aicoc-hub main > div:first-of-type h1 {
   font-weight: 800;
   letter-spacing: -0.02em;
   margin: 0 0 18px;
-  color: #fff;
+  background: linear-gradient(135deg, #fff 40%, rgb(180 195 255 / 85%) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 /* "Eyebrow" pill above the H1 — if author writes a small paragraph BEFORE
  * the H1, treat it as an eyebrow. */
 body.aicoc-hub main > div:first-of-type > p:first-child {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   margin: 0 auto 18px;
-  padding: 6px 16px;
-  font-size: 12px;
+  padding: 5px 14px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #fff;
-  background: linear-gradient(90deg, rgb(235 16 0 / 95%), rgb(255 59 47 / 95%));
+  color: rgb(255 255 255 / 55%);
+  background: rgb(255 255 255 / 6%);
+  border: 1px solid rgb(255 255 255 / 12%);
   border-radius: 999px;
 }
 
@@ -194,13 +204,13 @@ body.aicoc-hub main > div ~ div {
  * in the cascade. */
 @media (prefers-color-scheme: dark) {
   body.aicoc {
-    --aicoc-bg: #0b0b0d;
-    --aicoc-card: #2d2d33;
-    background-color: #0b0b0d;
+    --aicoc-bg: #080d1a;
+    --aicoc-card: #0d1325;
+    background-color: #080d1a;
   }
 
   body.aicoc main {
-    background-color: #0b0b0d;
+    background-color: #080d1a;
   }
 }
 


### PR DESCRIPTION
## Summary
Full visual refresh of the AI CoC hub and session pages:

- **Deep navy base** — `#0b0b0d` → `#080d1a` across hub hero, session heroes, card media areas, and dark mode backgrounds. Feels more "AI/tech", less generic dark mode.
- **Tri-color hub hero** — purple bloom (left) + blue bloom (right) + red accent (top-right). More depth and dimension vs. red-only.
- **Gradient H1 text** — white fading to cool blue-white (`rgb(180 195 255 / 85%)`). One line of CSS, big visual impact.
- **Frosted eyebrow pill** — ghost border style instead of solid red pill. Less aggressive, more refined.
- **Frosted badges on cards and session headers** — semi-transparent colored background + matching border instead of solid gradients. Works for both Show & Tell (red) and Brownbag (blue).
- **Purple complement bloom** — added to card media areas and session headers for both session types, giving warm/cool depth.
- **Frosted avatars** — presenter initials circles use tinted transparent background instead of solid gradient.

## Preview
- Hub: `https://feat-aicoc-design-refresh--inside-aem--adobe.aem.page/en/aicochub`
- Show & Tell: `https://feat-aicoc-design-refresh--inside-aem--adobe.aem.page/en/aicoc/ai-assisted-auditing-wiki-updates-jira-sampling-ldap-reviews`
- Brownbag: `https://feat-aicoc-design-refresh--inside-aem--adobe.aem.page/en/aicoc/unlocking-ai-productivity-with-easymcp-desktop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)