### PR TITLE
fix: collapse hidden hr section gap (robust selector)

### DIFF
--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -178,9 +178,10 @@ body.aicoc-hub main hr {
   display: none;
 }
 
-body.aicoc-hub main > div:has(> hr) {
-  margin: 0;
-  padding: 0;
+body.aicoc-hub main > div:has(hr) {
+  margin: 0 !important;
+  padding: 0 !important;
+  min-height: 0 !important;
 }
 
 /* Any section in main BEYOND the first one (where the session-feed sits).


### PR DESCRIPTION
## Summary
Previous fix used `:has(> hr)` (direct child only) but the `<hr>` is nested inside a wrapper div inside the section. Changed to `:has(hr)` (any descendant) and added `!important` to beat boilerplate margin/padding/min-height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)