### PR TITLE
feat: redesign session cards — format badge + SP avatar in card body

### DIFF
--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -35,11 +35,11 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  /* Show & Tell default — very light warm tint */
+  /* Show & Tell default — warm red tint */
   background:
-    radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 12%), transparent 60%),
-    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 6%), transparent 60%),
-    linear-gradient(135deg, #fff5f5 0%, #fff 100%);
+    radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 28%), transparent 60%),
+    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
+    linear-gradient(135deg, #ffecec 0%, #fff8f8 100%);
 }
 
 .session-card-media-picture,
@@ -232,9 +232,9 @@
 /* ── Brownbag variant (blue) ─────────────────────────────────────────────── */
 .session-card--brownbag .session-card-media {
   background:
-    radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 12%), transparent 60%),
-    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 6%), transparent 60%),
-    linear-gradient(135deg, #f0f6ff 0%, #fff 100%);
+    radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 28%), transparent 60%),
+    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
+    linear-gradient(135deg, #e8f0ff 0%, #f5f8ff 100%);
 }
 
 .session-card--brownbag .session-card-format {

--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -1,45 +1,36 @@
 /* AI CoC — session card.
- * Rendered inside session-feed. Self-contained styling so the card looks
- * right wherever it's placed, but assumes body.aicoc context for theme tone.
- *
  * Layout:
- *   - .session-card-media  — dark area: gradient/image, format pill, title
- *   - .session-card-body   — white area: description + presenter
+ *   - .session-card-media  — dark gradient area: AI CoC badge + title
+ *   - .session-card-body   — light area: format badge + date, description,
+ *                            divider, SP avatar + presenter
  */
 
 .session-card {
   display: flex;
   flex-direction: column;
-  background: #f5f5f7;
+  background: #fff;
   border: 1px solid #e5e5e7;
-  border-radius: 12px;
+  border-radius: 20px;
   overflow: hidden;
   text-decoration: none;
   color: inherit;
-  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+  transition: box-shadow 0.18s ease, transform 0.18s ease;
 }
 
 .session-card:hover,
 .session-card:focus-visible {
-  border-color: #EB1000;
-  box-shadow: 0 8px 24px rgb(235 16 0 / 12%);
+  box-shadow: 0 8px 32px rgb(0 0 0 / 14%);
   transform: translateY(-3px);
   text-decoration: none;
 }
 
-/* ── media (dark area) ─────────────────────────────────────────────────
- * Holds the format pill (top-left), the session title (bottom-left), and
- * an optional cover image with a gradient scrim for legibility.
- */
+/* ── media (dark area) ─────────────────────────────────────────────────── */
+
 .session-card-media {
   position: relative;
-
-  /* Compact dark/cover band — roughly half the height of the white body
-   * below. Sized to fit the pill + a 2-line title rather than a tall
-   * 16:9 cover. */
-  min-height: 132px;
+  min-height: 160px;
   overflow: hidden;
-  padding: 14px 18px 16px;
+  padding: 16px 20px 20px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -49,9 +40,6 @@
     linear-gradient(135deg, #080d1a 0%, #120609 100%);
 }
 
-/* When the session has its own cover image, the picture fills the media
- * area underneath the title, and a dark scrim ensures the title stays
- * readable regardless of the image's contrast. */
 .session-card-media-picture,
 .session-card-media-picture picture,
 .session-card-media-picture img {
@@ -71,40 +59,36 @@
   z-index: 1;
 }
 
-.session-card-format {
+/* "AI CoC" ghost badge — top-left of the media area */
+.session-card-ai-badge {
   position: relative;
   z-index: 2;
   align-self: flex-start;
   padding: 3px 10px;
   font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: rgb(255 160 150 / 95%);
-  background: rgb(235 16 0 / 18%);
-  border: 1px solid rgb(235 16 0 / 35%);
+  color: rgb(255 255 255 / 55%);
+  background: rgb(255 255 255 / 8%);
+  border: 1px solid rgb(255 255 255 / 14%);
   border-radius: 999px;
-  box-shadow: none;
   margin-bottom: auto;
 }
 
 .session-card-title {
   position: relative;
   z-index: 2;
-  margin: 16px 0 0;
-  font-size: 18px;
+  margin: 14px 0 0;
+  font-size: 17px;
   font-weight: 700;
   line-height: 1.3;
   color: #fff;
   text-shadow: 0 1px 12px rgb(0 0 0 / 40%);
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-.session-card:hover .session-card-title {
-  color: #fff;
 }
 
 .session-card-play {
@@ -121,8 +105,8 @@
 
 .session-card-play .icon,
 .session-card-play svg {
-  width: 56px;
-  height: 56px;
+  width: 48px;
+  height: 48px;
   color: #fff;
   fill: #fff;
   filter: drop-shadow(0 4px 16px rgb(0 0 0 / 45%));
@@ -136,31 +120,47 @@
   justify-content: center;
 }
 
-.session-card-play .icon svg {
-  width: 100%;
-  height: 100%;
-  filter: none;
-}
+.session-card-play .icon svg { width: 100%; height: 100%; filter: none; }
 
 .session-card:hover .session-card-play,
-.session-card:focus-visible .session-card-play {
-  opacity: 1;
-}
+.session-card:focus-visible .session-card-play { opacity: 1; }
 
-.session-card:hover .session-card-play svg {
-  transform: scale(1);
-}
+.session-card:hover .session-card-play svg { transform: scale(1); }
 
-/* ── body (white area) ─────────────────────────────────────────────────
- * Description + meta row (date · presenter). Title lives in the dark media
- * area above; only the secondary details are in the white body.
- */
+/* ── body (light area) ─────────────────────────────────────────────────── */
+
 .session-card-body {
-  padding: 16px 18px 18px;
+  padding: 16px 20px 18px;
   display: flex;
   flex-direction: column;
   gap: 10px;
   flex: 1;
+  background: #fff;
+}
+
+/* Format badge + date row */
+.session-card-format-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.session-card-format {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  padding: 3px 10px;
+  /* Show & Tell default — red */
+  color: rgb(200 30 20 / 95%);
+  background: rgb(235 16 0 / 10%);
+  border: 1px solid rgb(235 16 0 / 20%);
+}
+
+.session-card-date {
+  font-size: 13px;
+  color: #8e8e93;
 }
 
 .session-card-description {
@@ -169,46 +169,51 @@
   color: #4a4a4f;
   margin: 0;
   display: -webkit-box;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  flex: 1;
 }
 
-/* Meta row — "Jun 2, 2026 · Presenter Name" */
-.session-card-meta {
-  font-size: 13px;
-  color: #6e6e73;
-  margin: 0;
-  margin-top: auto;
+.session-card-divider {
+  border: none;
+  border-top: 1px solid #e5e5e7;
+  margin: 2px 0 0;
+}
+
+/* Presenter row — SP avatar + name */
+.session-card-presenter-row {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
+  gap: 10px;
+}
+
+.session-card-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+  /* Show & Tell default — red */
+  background: rgb(235 16 0 / 18%);
+  color: rgb(200 30 20 / 95%);
+  border: 1px solid rgb(235 16 0 / 25%);
 }
 
 .session-card-presenter {
+  font-size: 14px;
   font-weight: 600;
   color: #0b0b0d;
 }
 
-.session-card-sep {
-  color: #c5c5cd;
-}
-
-/* ── No-image cards ───────────────────────────────────────────────────────
- * Sessions without a per-session cover image keep the dark gradient band
- * (with the format pill and the title) at the same compact height as image
- * cards, so the dark area stays ~half the white body. We only drop the hover
- * play overlay, since there's no thumbnail to "play" into.
- *
- * The `--no-image` modifier is intentional BEM-style on top of the kebab
- * base class — disable the linter for these selectors only.
- */
+/* ── No-image cards ──────────────────────────────────────────────────────── */
 /* stylelint-disable selector-class-pattern, no-descending-specificity */
-.session-card--no-image .session-card-placeholder,
-.session-card--no-image .session-card-play {
-  display: none;
-}
+.session-card--no-image .session-card-play { display: none; }
 
 .session-card--no-image .session-card-media::before {
   content: "";
@@ -221,13 +226,8 @@
   background-size: 40px 40px, 30px 30px, 60px 60px;
   pointer-events: none;
 }
-/* stylelint-enable selector-class-pattern, no-descending-specificity */
 
-/* ── Brownbag variant (blue) ──────────────────────────────────────────────
- * AI Assisted Brownbag sessions get a blue gradient instead of red.
- * Only the media background, format badge, and hover accent change.
- */
-/* stylelint-disable selector-class-pattern */
+/* ── Brownbag variant (blue) ─────────────────────────────────────────────── */
 .session-card--brownbag .session-card-media {
   background:
     radial-gradient(600px 300px at 80% 20%, rgb(2 101 220 / 45%), transparent 60%),
@@ -236,55 +236,42 @@
 }
 
 .session-card--brownbag .session-card-format {
+  color: rgb(2 90 200 / 95%);
+  background: rgb(2 101 220 / 10%);
+  border-color: rgb(2 101 220 / 20%);
+}
+
+.session-card--brownbag .session-card-avatar {
   background: rgb(2 101 220 / 18%);
-  border: 1px solid rgb(2 101 220 / 35%);
-  color: rgb(100 180 250 / 95%);
+  color: rgb(2 90 200 / 95%);
+  border-color: rgb(2 101 220 / 25%);
 }
 
 .session-card--brownbag:hover,
 .session-card--brownbag:focus-visible {
-  border-color: #0265DC;
-  box-shadow: 0 8px 24px rgb(2 101 220 / 12%);
+  box-shadow: 0 8px 32px rgb(2 101 220 / 14%);
 }
-/* stylelint-enable selector-class-pattern */
+/* stylelint-enable selector-class-pattern, no-descending-specificity */
 
-/* ── Dark mode ────────────────────────────────────────────────────────────
- * The AI CoC hub is intentionally dark-themed even in light mode (red
- * gradient hero), so a bright white card body sitting on a near-black page
- * looks jarring when the OS dark mode is on. Mirror the page tone by
- * darkening the card itself and flipping the text colors.
- *
- * Scoped under prefers-color-scheme so light-mode rendering is byte-identical.
- */
+/* ── Dark mode ───────────────────────────────────────────────────────────── */
 @media (prefers-color-scheme: dark) {
   .session-card {
     background: #0d1325;
     border-color: rgb(255 255 255 / 8%);
   }
 
+  .session-card-body { background: #0d1325; }
+
   .session-card:hover,
   .session-card:focus-visible {
-    /* Brighter shadow so the hover lift still reads on a dark page. */
-    box-shadow: 0 8px 24px rgb(0 0 0 / 60%);
+    box-shadow: 0 8px 32px rgb(0 0 0 / 50%);
   }
 
-  .session-card-title {
-    color: #f5f5f7;
-  }
+  .session-card-description { color: #b0b0b8; }
 
-  .session-card-description {
-    color: #d4d4d8;
-  }
+  .session-card-date { color: #6e6e73; }
 
-  .session-card-meta {
-    color: #9a9aa0;
-  }
+  .session-card-presenter { color: #f0f0f5; }
 
-  .session-card-presenter {
-    color: #f5f5f7;
-  }
-
-  .session-card-sep {
-    color: #666;
-  }
+  .session-card-divider { border-color: rgb(255 255 255 / 8%); }
 }

--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -9,12 +9,13 @@
   display: flex;
   flex-direction: column;
   background: #fff;
-  border: 1px solid #e5e5e7;
+  border: 1px solid #e0e0e4;
   border-radius: 20px;
   overflow: hidden;
   text-decoration: none;
   color: inherit;
   transition: box-shadow 0.18s ease, transform 0.18s ease;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
 }
 
 .session-card:hover,
@@ -24,7 +25,7 @@
   text-decoration: none;
 }
 
-/* ── media (dark area) ─────────────────────────────────────────────────── */
+/* ── media (light tinted area) ─────────────────────────────────────────── */
 
 .session-card-media {
   position: relative;
@@ -34,10 +35,11 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  /* Show & Tell default — very light warm tint */
   background:
-    radial-gradient(600px 300px at 80% 20%, rgb(235 16 0 / 45%), transparent 60%),
-    radial-gradient(400px 300px at 10% 90%, rgb(99 60 255 / 20%), transparent 60%),
-    linear-gradient(135deg, #080d1a 0%, #120609 100%);
+    radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 12%), transparent 60%),
+    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 6%), transparent 60%),
+    linear-gradient(135deg, #fff5f5 0%, #fff 100%);
 }
 
 .session-card-media-picture,
@@ -55,7 +57,7 @@
 .session-card-media-scrim {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgb(0 0 0 / 10%) 0%, rgb(0 0 0 / 65%) 100%);
+  background: linear-gradient(180deg, rgb(255 255 255 / 0%) 0%, rgb(255 255 255 / 40%) 100%);
   z-index: 1;
 }
 
@@ -69,9 +71,9 @@
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: rgb(255 255 255 / 55%);
-  background: rgb(255 255 255 / 8%);
-  border: 1px solid rgb(255 255 255 / 14%);
+  color: rgb(235 16 0 / 60%);
+  background: rgb(235 16 0 / 6%);
+  border: 1px solid rgb(235 16 0 / 18%);
   border-radius: 999px;
   margin-bottom: auto;
 }
@@ -83,8 +85,8 @@
   font-size: 17px;
   font-weight: 700;
   line-height: 1.3;
-  color: #fff;
-  text-shadow: 0 1px 12px rgb(0 0 0 / 40%);
+  color: #0b0b0d;
+  text-shadow: none;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -107,9 +109,9 @@
 .session-card-play svg {
   width: 48px;
   height: 48px;
-  color: #fff;
-  fill: #fff;
-  filter: drop-shadow(0 4px 16px rgb(0 0 0 / 45%));
+  color: rgb(235 16 0 / 80%);
+  fill: rgb(235 16 0 / 80%);
+  filter: drop-shadow(0 4px 16px rgb(0 0 0 / 20%));
   transform: scale(0.85);
   transition: transform 0.2s ease;
 }
@@ -220,9 +222,9 @@
   position: absolute;
   inset: 0;
   background-image:
-    radial-gradient(circle at 20% 30%, rgb(255 255 255 / 6%) 0 1px, transparent 1px),
-    radial-gradient(circle at 70% 80%, rgb(255 255 255 / 5%) 0 1px, transparent 1px),
-    radial-gradient(circle at 90% 20%, rgb(255 255 255 / 5%) 0 1px, transparent 1px);
+    radial-gradient(circle at 20% 30%, rgb(235 16 0 / 8%) 0 1px, transparent 1px),
+    radial-gradient(circle at 70% 80%, rgb(235 16 0 / 6%) 0 1px, transparent 1px),
+    radial-gradient(circle at 90% 20%, rgb(235 16 0 / 5%) 0 1px, transparent 1px);
   background-size: 40px 40px, 30px 30px, 60px 60px;
   pointer-events: none;
 }
@@ -230,9 +232,9 @@
 /* ── Brownbag variant (blue) ─────────────────────────────────────────────── */
 .session-card--brownbag .session-card-media {
   background:
-    radial-gradient(600px 300px at 80% 20%, rgb(2 101 220 / 45%), transparent 60%),
-    radial-gradient(400px 300px at 10% 90%, rgb(99 60 255 / 20%), transparent 60%),
-    linear-gradient(135deg, #080d1a 0%, #060e1a 100%);
+    radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 12%), transparent 60%),
+    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 6%), transparent 60%),
+    linear-gradient(135deg, #f0f6ff 0%, #fff 100%);
 }
 
 .session-card--brownbag .session-card-format {
@@ -247,6 +249,25 @@
   border-color: rgb(2 101 220 / 25%);
 }
 
+.session-card--brownbag .session-card-ai-badge {
+  color: rgb(2 101 220 / 60%);
+  background: rgb(2 101 220 / 6%);
+  border-color: rgb(2 101 220 / 18%);
+}
+
+.session-card--brownbag .session-card-play .icon,
+.session-card--brownbag .session-card-play svg {
+  color: rgb(2 101 220 / 80%);
+  fill: rgb(2 101 220 / 80%);
+}
+
+.session-card--brownbag--no-image .session-card-media::before {
+  background-image:
+    radial-gradient(circle at 20% 30%, rgb(2 101 220 / 8%) 0 1px, transparent 1px),
+    radial-gradient(circle at 70% 80%, rgb(2 101 220 / 6%) 0 1px, transparent 1px),
+    radial-gradient(circle at 90% 20%, rgb(2 101 220 / 5%) 0 1px, transparent 1px);
+}
+
 .session-card--brownbag:hover,
 .session-card--brownbag:focus-visible {
   box-shadow: 0 8px 32px rgb(2 101 220 / 14%);
@@ -256,11 +277,39 @@
 /* ── Dark mode ───────────────────────────────────────────────────────────── */
 @media (prefers-color-scheme: dark) {
   .session-card {
-    background: #0d1325;
+    background: #1a1a22;
     border-color: rgb(255 255 255 / 8%);
   }
 
-  .session-card-body { background: #0d1325; }
+  .session-card-media {
+    background:
+      radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 20%), transparent 60%),
+      radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
+      linear-gradient(135deg, #1f1015 0%, #1a1a22 100%);
+  }
+
+  .session-card--brownbag .session-card-media {
+    background:
+      radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 20%), transparent 60%),
+      radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
+      linear-gradient(135deg, #0f1520 0%, #1a1a22 100%);
+  }
+
+  .session-card-title { color: #f0f0f5; }
+
+  .session-card-ai-badge {
+    color: rgb(255 100 90 / 70%);
+    background: rgb(235 16 0 / 10%);
+    border-color: rgb(235 16 0 / 20%);
+  }
+
+  .session-card--brownbag .session-card-ai-badge {
+    color: rgb(80 160 240 / 70%);
+    background: rgb(2 101 220 / 10%);
+    border-color: rgb(2 101 220 / 20%);
+  }
+
+  .session-card-body { background: #1a1a22; }
 
   .session-card:hover,
   .session-card:focus-visible {

--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -37,9 +37,9 @@
   justify-content: flex-end;
   /* Show & Tell default — warm red tint */
   background:
-    radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 28%), transparent 60%),
-    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
-    linear-gradient(135deg, #ffecec 0%, #fff8f8 100%);
+    radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 50%), transparent 60%),
+    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 14%), transparent 60%),
+    linear-gradient(135deg, #ffe0e0 0%, #fff4f4 100%);
 }
 
 .session-card-media-picture,
@@ -232,9 +232,9 @@
 /* ── Brownbag variant (blue) ─────────────────────────────────────────────── */
 .session-card--brownbag .session-card-media {
   background:
-    radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 28%), transparent 60%),
-    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
-    linear-gradient(135deg, #e8f0ff 0%, #f5f8ff 100%);
+    radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 50%), transparent 60%),
+    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 14%), transparent 60%),
+    linear-gradient(135deg, #ddeaff 0%, #f0f5ff 100%);
 }
 
 .session-card--brownbag .session-card-format {

--- a/blocks/session-card/session-card.js
+++ b/blocks/session-card/session-card.js
@@ -68,7 +68,7 @@ export function buildSessionCard(session, eager = false) {
   card.href = path;
 
   // ── media (dark area) ────────────────────────────────────────────────
-  // Holds: optional cover image, format pill, session title, play overlay.
+  // Holds: "AI CoC" ghost badge (top-left), title (bottom), play overlay.
   const media = document.createElement('div');
   media.className = 'session-card-media';
 
@@ -76,45 +76,51 @@ export function buildSessionCard(session, eager = false) {
     const picture = createOptimizedPicture(image, imageAlt || title, eager, [{ width: '600' }]);
     picture.classList.add('session-card-media-picture');
     media.append(picture);
-    // Gradient overlay so the title stays legible over any image.
     const scrim = document.createElement('div');
     scrim.className = 'session-card-media-scrim';
     scrim.setAttribute('aria-hidden', 'true');
     media.append(scrim);
-  } else {
-    // No image — the gradient placeholder is provided by .session-card-media's
-    // own background, so there's nothing to inject here.
   }
 
-  // Format badge (first tag — e.g. "Brownbag", "Show & Tell").
-  const format = tags[0];
-  if (format) {
-    const badge = document.createElement('span');
-    badge.className = 'session-card-format';
-    badge.textContent = format;
-    media.append(badge);
-  }
+  // "AI CoC" ghost badge — always shown in the media area.
+  const aiBadge = document.createElement('span');
+  aiBadge.className = 'session-card-ai-badge';
+  aiBadge.textContent = 'AI CoC';
+  media.append(aiBadge);
 
-  // Title lives inside the dark area now — the white body below is for the
-  // description and presenter only.
   const titleEl = document.createElement('h3');
   titleEl.className = 'session-card-title';
   titleEl.textContent = title || '';
   media.append(titleEl);
 
-  // Play-button overlay so the recording affordance is visible on hover.
-  // The inner <span class="icon icon-play"> is swapped for the inline SVG by
-  // decorateIcons() in session-feed.js after the card is appended.
   media.insertAdjacentHTML(
     'beforeend',
     '<span class="session-card-play" aria-hidden="true"><span class="icon icon-play"></span></span>',
   );
 
-  // ── body (white area) ────────────────────────────────────────────────
-  // Description + presenter only. No title (in the dark area above) and no
-  // date (already encoded in the chronological order of the feed).
+  // ── body (light area) ────────────────────────────────────────────────
+  // Format badge + date, description, divider, SP avatar + presenter.
   const body = document.createElement('div');
   body.className = 'session-card-body';
+
+  // Format badge + date row
+  const formatRow = document.createElement('div');
+  formatRow.className = 'session-card-format-row';
+  const format = tags[0];
+  if (format) {
+    const badge = document.createElement('span');
+    badge.className = 'session-card-format';
+    badge.textContent = /brownbag/i.test(title) ? 'Brownbag' : 'Show & Tell';
+    formatRow.append(badge);
+  }
+  const dateText = formatSessionDate(sessionDate);
+  if (dateText) {
+    const dateEl = document.createElement('span');
+    dateEl.className = 'session-card-date';
+    dateEl.textContent = dateText;
+    formatRow.append(dateEl);
+  }
+  body.append(formatRow);
 
   if (description) {
     const descEl = document.createElement('p');
@@ -123,14 +129,26 @@ export function buildSessionCard(session, eager = false) {
     body.append(descEl);
   }
 
-  const meta = document.createElement('p');
-  meta.className = 'session-card-meta';
-  const parts = [];
-  const dateText = formatSessionDate(sessionDate);
-  if (dateText) parts.push(`<span class="session-card-date">${dateText}</span>`);
-  if (presenter) parts.push(`<span class="session-card-presenter">${presenter}</span>`);
-  meta.innerHTML = parts.join('<span class="session-card-sep">·</span>');
-  body.append(meta);
+  // Divider + presenter row
+  const divider = document.createElement('hr');
+  divider.className = 'session-card-divider';
+  body.append(divider);
+
+  const presenterRow = document.createElement('div');
+  presenterRow.className = 'session-card-presenter-row';
+
+  const avatar = document.createElement('span');
+  avatar.className = 'session-card-avatar';
+  avatar.textContent = 'SP';
+  presenterRow.append(avatar);
+
+  if (presenter) {
+    const presenterEl = document.createElement('span');
+    presenterEl.className = 'session-card-presenter';
+    presenterEl.textContent = presenter;
+    presenterRow.append(presenterEl);
+  }
+  body.append(presenterRow);
 
   card.append(media, body);
   return card;


### PR DESCRIPTION
## Summary
Matches the new card design:

- **Media area**: Ghost "AI CoC" badge (top-left) + bold title. No format badge here anymore.
- **Card body**: Format badge (Brownbag blue / Show & Tell red) + date on one row, description, horizontal divider, then SP avatar circle + presenter name
- **SP avatar**: Always shows "SP" (speaker), colored to match card type — blue for Brownbag, red for Show & Tell
- **Rounder corners**: 12px → 20px
- Brownbag and Show & Tell hover glows updated to match

## Preview
`https://feat-card-redesign--inside-aem--adobe.aem.page/en/aicochub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)