### PR TITLE
fix: center hub hero content

### DIFF
--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -121,6 +121,7 @@ body.aicoc-hub main > div:first-of-type > * {
   max-width: 880px;
   margin-left: auto;
   margin-right: auto;
+  text-align: center;
 }
 
 /* Title */


### PR DESCRIPTION
## Summary
- Adds `text-align: center` explicitly to the inner content wrapper of the hub hero
- EDS wraps section content in a `default-content-wrapper` div that was intercepting the inherited `text-align` from the outer section rule

## Test plan
- [ ] Preview `fix-hub-hero-centering--inside-aem--adobe.aem.page/en/aicochub` — hero text should be centered
- [ ] Merge and publish `/en/aicochub` via Sidekick

🤖 Generated with [Claude Code](https://claude.com/claude-code)