### PR TITLE
fix: keep hub hero centered when feed shares hero section

### DIFF
--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -179,8 +179,12 @@ body.aicoc-hub main hr {
   display: none;
 }
 
+/* When the author omits the "---" separator, the H1 + tagline + session-feed
+ * all land in ONE section that also contains the (hidden) hr. That section is
+ * the hero, so it must stay horizontally centred — use `0 auto`, not `0`, or
+ * the centring margins collapse and the whole 1200px box pins to the left. */
 body.aicoc-hub main > div:has(hr) {
-  margin: 0 !important;
+  margin: 0 auto !important;
   padding: 0 !important;
   min-height: 0 !important;
 }


### PR DESCRIPTION
## The bug
On the live hub, the dark hero box + content column was pinned to the left with a large white gap on the right.

## Root cause (confirmed via live DOM inspection)
The author's doc has no \`---\` separator, so the H1 + tagline + \`session-feed\` all render in **one** \`main > div\` section — and that section also contains the (hidden) \`hr\`. The hr-collapse rule:

\`\`\`css
body.aicoc-hub main > div:has(hr) { margin: 0 !important; ... }
\`\`\`

matched the hero section and overrode its \`margin: 32px auto 0\`, so \`margin-left/right\` became \`0\` instead of \`auto\` → the 1200px box pinned left.

Live inspection showed: \`hero.width=1200, left=0, marginLeft=0px, marginRight=0px, hasHr=yes\` in a 2225px viewport.

## Fix
Change \`margin: 0 !important\` → \`margin: 0 auto !important\`. Vertical spacing still collapses; horizontal centering is preserved.

## Test plan
- [ ] Merge, then Sidekick **Preview → Publish** on \`/en/aicochub\`
- [ ] Hard-refresh — dark hero box and card grid should be horizontally centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)