### PR TITLE
feat: brand-aligned redesign (Adobe red/black/white)

### DIFF
--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -230,7 +230,7 @@
 /* Darker (near-black) media gives Brownbag a clear identity vs the Show & Tell
  * red flood, while staying inside the red/black/white palette. */
 .session-card--brownbag .session-card-media {
-  background: linear-gradient(160deg, #3a3a3f 0%, #1c1c1f 100%);
+  background: linear-gradient(160deg, #6a6a70 0%, #45454b 100%);
 }
 
 .session-card--brownbag .session-card-title { color: #fff; }

--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -225,22 +225,20 @@
 /* stylelint-disable selector-class-pattern, no-descending-specificity */
 .session-card--no-image .session-card-play { display: none; }
 
-/* ── Brownbag variant — red OUTLINE on white ─────────────────────────────── */
+/* ── Brownbag variant — dark header, red OUTLINE labels ──────────────────── */
+
+/* Darker (near-black) media gives Brownbag a clear identity vs the Show & Tell
+ * red flood, while staying inside the red/black/white palette. */
 .session-card--brownbag .session-card-media {
-  background: #fff;
-  border-bottom: 1px solid var(--aicoc-border, #e5e5e7);
+  background: linear-gradient(160deg, #3a3a3f 0%, #1c1c1f 100%);
 }
 
-/* On a white media area, the title and badge flip to ink + red. */
-.session-card--brownbag .session-card-title { color: #000; }
+.session-card--brownbag .session-card-title { color: #fff; }
 
 .session-card--brownbag .session-card-ai-badge {
-  color: var(--card-red);
-  border-color: var(--card-red);
+  color: #fff;
+  border-color: #fff;
 }
-
-/* Image brownbag cards keep a scrim + white title for legibility. */
-.session-card--brownbag.session-card:not(.session-card--no-image) .session-card-title { color: #fff; }
 
 .session-card--brownbag .session-card-format {
   color: var(--card-red);
@@ -271,11 +269,9 @@
 
   .session-card-body { background: #141414; }
 
-  /* Show & Tell keeps the red flood; Brownbag media goes black with a red
-   * separator so the outline language still reads. */
+  /* Show & Tell keeps the red flood; Brownbag media stays dark. */
   .session-card--brownbag .session-card-media {
-    background: #141414;
-    border-bottom-color: var(--card-red);
+    background: linear-gradient(160deg, #242428 0%, #141414 100%);
   }
 
   .session-card--brownbag .session-card-format,

--- a/blocks/session-card/session-card.css
+++ b/blocks/session-card/session-card.css
@@ -1,16 +1,25 @@
-/* AI CoC — session card.
+/* AI CoC — session card (Adobe brand-aligned: red / black / white, solid
+ * colours, no tints or transparencies).
+ *
+ * Format differentiation = red FILL vs red OUTLINE:
+ *   - Show & Tell (default): solid Adobe red media + red-fill label/avatar
+ *   - Brownbag (--brownbag):  white media + red-OUTLINE label/avatar
+ *
  * Layout:
- *   - .session-card-media  — dark gradient area: AI CoC badge + title
- *   - .session-card-body   — light area: format badge + date, description,
+ *   - .session-card-media  — header area (red flood or image): AI CoC + title
+ *   - .session-card-body   — white area: format label + date, description,
  *                            divider, SP avatar + presenter
  */
 
 .session-card {
+  --card-red: #eb1000;
+  --card-red-deep: #b30c00;
+
   display: flex;
   flex-direction: column;
   background: #fff;
   border: 1px solid #e0e0e4;
-  border-radius: 20px;
+  border-radius: 16px;
   overflow: hidden;
   text-decoration: none;
   color: inherit;
@@ -20,26 +29,23 @@
 
 .session-card:hover,
 .session-card:focus-visible {
-  box-shadow: 0 8px 32px rgb(0 0 0 / 14%);
+  box-shadow: 0 10px 30px rgb(0 0 0 / 16%);
   transform: translateY(-3px);
   text-decoration: none;
 }
 
-/* ── media (light tinted area) ─────────────────────────────────────────── */
+/* ── media (header area) ───────────────────────────────────────────────── */
 
+/* Show & Tell default — solid Adobe red flood, white text. */
 .session-card-media {
   position: relative;
-  min-height: 160px;
+  min-height: 150px;
   overflow: hidden;
   padding: 16px 20px 20px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  /* Show & Tell default — warm red tint */
-  background:
-    radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 50%), transparent 60%),
-    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 14%), transparent 60%),
-    linear-gradient(135deg, #ffe0e0 0%, #fff4f4 100%);
+  background: var(--card-red);
 }
 
 .session-card-media-picture,
@@ -54,14 +60,16 @@
   z-index: 0;
 }
 
+/* Scrim only sits over photos, for title legibility. */
 .session-card-media-scrim {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgb(255 255 255 / 0%) 0%, rgb(255 255 255 / 40%) 100%);
+  background: linear-gradient(180deg, rgb(0 0 0 / 0%) 30%, rgb(0 0 0 / 60%) 100%);
   z-index: 1;
 }
 
-/* "AI CoC" ghost badge — top-left of the media area */
+/* "AI CoC" badge — top-left of the media area. On the red flood it's a
+ * white outline pill. */
 .session-card-ai-badge {
   position: relative;
   z-index: 2;
@@ -71,9 +79,9 @@
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: rgb(235 16 0 / 60%);
-  background: rgb(235 16 0 / 6%);
-  border: 1px solid rgb(235 16 0 / 18%);
+  color: #fff;
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 70%);
   border-radius: 999px;
   margin-bottom: auto;
 }
@@ -83,10 +91,10 @@
   z-index: 2;
   margin: 14px 0 0;
   font-size: 17px;
-  font-weight: 700;
-  line-height: 1.3;
-  color: #0b0b0d;
-  text-shadow: none;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: #fff;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -109,9 +117,9 @@
 .session-card-play svg {
   width: 48px;
   height: 48px;
-  color: rgb(235 16 0 / 80%);
-  fill: rgb(235 16 0 / 80%);
-  filter: drop-shadow(0 4px 16px rgb(0 0 0 / 20%));
+  color: #fff;
+  fill: #fff;
+  filter: drop-shadow(0 4px 16px rgb(0 0 0 / 45%));
   transform: scale(0.85);
   transition: transform 0.2s ease;
 }
@@ -129,7 +137,7 @@
 
 .session-card:hover .session-card-play svg { transform: scale(1); }
 
-/* ── body (light area) ─────────────────────────────────────────────────── */
+/* ── body (white area) ─────────────────────────────────────────────────── */
 
 .session-card-body {
   padding: 16px 20px 18px;
@@ -140,35 +148,35 @@
   background: #fff;
 }
 
-/* Format badge + date row */
+/* Format label + date row */
 .session-card-format-row {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
+/* Show & Tell — solid red fill, white text. */
 .session-card-format {
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
   border-radius: 999px;
-  padding: 3px 10px;
-  /* Show & Tell default — red */
-  color: rgb(200 30 20 / 95%);
-  background: rgb(235 16 0 / 10%);
-  border: 1px solid rgb(235 16 0 / 20%);
+  padding: 4px 11px;
+  color: #fff;
+  background: var(--card-red);
+  border: 1px solid var(--card-red);
 }
 
 .session-card-date {
   font-size: 13px;
-  color: #8e8e93;
+  color: #6e6e73;
 }
 
 .session-card-description {
   font-size: 14px;
   line-height: 1.5;
-  color: #4a4a4f;
+  color: #2c2c2e;
   margin: 0;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -190,6 +198,7 @@
   gap: 10px;
 }
 
+/* Show & Tell — solid red circle, white "SP". */
 .session-card-avatar {
   width: 32px;
   height: 32px;
@@ -201,126 +210,90 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   flex-shrink: 0;
-  /* Show & Tell default — red */
-  background: rgb(235 16 0 / 18%);
-  color: rgb(200 30 20 / 95%);
-  border: 1px solid rgb(235 16 0 / 25%);
+  color: #fff;
+  background: var(--card-red);
+  border: 1px solid var(--card-red);
 }
 
 .session-card-presenter {
   font-size: 14px;
   font-weight: 600;
-  color: #0b0b0d;
+  color: #000;
 }
 
 /* ── No-image cards ──────────────────────────────────────────────────────── */
 /* stylelint-disable selector-class-pattern, no-descending-specificity */
 .session-card--no-image .session-card-play { display: none; }
 
-.session-card--no-image .session-card-media::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image:
-    radial-gradient(circle at 20% 30%, rgb(235 16 0 / 8%) 0 1px, transparent 1px),
-    radial-gradient(circle at 70% 80%, rgb(235 16 0 / 6%) 0 1px, transparent 1px),
-    radial-gradient(circle at 90% 20%, rgb(235 16 0 / 5%) 0 1px, transparent 1px);
-  background-size: 40px 40px, 30px 30px, 60px 60px;
-  pointer-events: none;
+/* ── Brownbag variant — red OUTLINE on white ─────────────────────────────── */
+.session-card--brownbag .session-card-media {
+  background: #fff;
+  border-bottom: 1px solid var(--aicoc-border, #e5e5e7);
 }
 
-/* ── Brownbag variant (blue) ─────────────────────────────────────────────── */
-.session-card--brownbag .session-card-media {
-  background:
-    radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 50%), transparent 60%),
-    radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 14%), transparent 60%),
-    linear-gradient(135deg, #ddeaff 0%, #f0f5ff 100%);
+/* On a white media area, the title and badge flip to ink + red. */
+.session-card--brownbag .session-card-title { color: #000; }
+
+.session-card--brownbag .session-card-ai-badge {
+  color: var(--card-red);
+  border-color: var(--card-red);
 }
+
+/* Image brownbag cards keep a scrim + white title for legibility. */
+.session-card--brownbag.session-card:not(.session-card--no-image) .session-card-title { color: #fff; }
 
 .session-card--brownbag .session-card-format {
-  color: rgb(2 90 200 / 95%);
-  background: rgb(2 101 220 / 10%);
-  border-color: rgb(2 101 220 / 20%);
+  color: var(--card-red);
+  background: #fff;
+  border-color: var(--card-red);
 }
 
 .session-card--brownbag .session-card-avatar {
-  background: rgb(2 101 220 / 18%);
-  color: rgb(2 90 200 / 95%);
-  border-color: rgb(2 101 220 / 25%);
-}
-
-.session-card--brownbag .session-card-ai-badge {
-  color: rgb(2 101 220 / 60%);
-  background: rgb(2 101 220 / 6%);
-  border-color: rgb(2 101 220 / 18%);
+  color: var(--card-red);
+  background: #fff;
+  border-color: var(--card-red);
 }
 
 .session-card--brownbag .session-card-play .icon,
 .session-card--brownbag .session-card-play svg {
-  color: rgb(2 101 220 / 80%);
-  fill: rgb(2 101 220 / 80%);
-}
-
-.session-card--brownbag--no-image .session-card-media::before {
-  background-image:
-    radial-gradient(circle at 20% 30%, rgb(2 101 220 / 8%) 0 1px, transparent 1px),
-    radial-gradient(circle at 70% 80%, rgb(2 101 220 / 6%) 0 1px, transparent 1px),
-    radial-gradient(circle at 90% 20%, rgb(2 101 220 / 5%) 0 1px, transparent 1px);
-}
-
-.session-card--brownbag:hover,
-.session-card--brownbag:focus-visible {
-  box-shadow: 0 8px 32px rgb(2 101 220 / 14%);
+  color: var(--card-red);
+  fill: var(--card-red);
 }
 /* stylelint-enable selector-class-pattern, no-descending-specificity */
 
-/* ── Dark mode ───────────────────────────────────────────────────────────── */
+/* ── Dark mode (true black, brand red accents) ───────────────────────────── */
+/* stylelint-disable selector-class-pattern, no-descending-specificity */
 @media (prefers-color-scheme: dark) {
   .session-card {
-    background: #1a1a22;
-    border-color: rgb(255 255 255 / 8%);
+    background: #141414;
+    border-color: #2a2a2a;
   }
 
-  .session-card-media {
-    background:
-      radial-gradient(500px 300px at 90% 10%, rgb(235 16 0 / 20%), transparent 60%),
-      radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
-      linear-gradient(135deg, #1f1015 0%, #1a1a22 100%);
-  }
+  .session-card-body { background: #141414; }
 
+  /* Show & Tell keeps the red flood; Brownbag media goes black with a red
+   * separator so the outline language still reads. */
   .session-card--brownbag .session-card-media {
-    background:
-      radial-gradient(500px 300px at 90% 10%, rgb(2 101 220 / 20%), transparent 60%),
-      radial-gradient(300px 200px at 5% 90%, rgb(99 60 255 / 10%), transparent 60%),
-      linear-gradient(135deg, #0f1520 0%, #1a1a22 100%);
+    background: #141414;
+    border-bottom-color: var(--card-red);
   }
 
-  .session-card-title { color: #f0f0f5; }
-
-  .session-card-ai-badge {
-    color: rgb(255 100 90 / 70%);
-    background: rgb(235 16 0 / 10%);
-    border-color: rgb(235 16 0 / 20%);
+  .session-card--brownbag .session-card-format,
+  .session-card--brownbag .session-card-avatar {
+    background: #141414;
   }
-
-  .session-card--brownbag .session-card-ai-badge {
-    color: rgb(80 160 240 / 70%);
-    background: rgb(2 101 220 / 10%);
-    border-color: rgb(2 101 220 / 20%);
-  }
-
-  .session-card-body { background: #1a1a22; }
 
   .session-card:hover,
   .session-card:focus-visible {
-    box-shadow: 0 8px 32px rgb(0 0 0 / 50%);
+    box-shadow: 0 10px 30px rgb(0 0 0 / 60%);
   }
 
-  .session-card-description { color: #b0b0b8; }
+  .session-card-description { color: #c8c8c8; }
 
-  .session-card-date { color: #6e6e73; }
+  .session-card-date { color: #8a8a8a; }
 
-  .session-card-presenter { color: #f0f0f5; }
+  .session-card-presenter { color: #fff; }
 
-  .session-card-divider { border-color: rgb(255 255 255 / 8%); }
+  .session-card-divider { border-color: #2a2a2a; }
 }
+/* stylelint-enable selector-class-pattern, no-descending-specificity */

--- a/blocks/session-header/session-header.css
+++ b/blocks/session-header/session-header.css
@@ -1,6 +1,10 @@
-/* AI CoC — session header block.
+/* AI CoC — session header block (Adobe brand-aligned: red / black / white,
+ * solid colours, no tints/frost/gradients).
  * Only renders on /en/aicoc/<slug> pages where body.aicoc-session is set.
- * Styles are namespaced under .session-header to avoid any blog leakage.
+ *
+ * Format differentiation mirrors the cards (red FILL vs red OUTLINE):
+ *   - Show & Tell (default): solid Adobe red flood hero, white text
+ *   - Brownbag (--brownbag):  white hero, black text, red accents
  */
 
 main .session-header-container,
@@ -19,37 +23,20 @@ main .session-header {
 
 /* ── HERO ─────────────────────────────────────────────────────────────── */
 
-/* Contained, rounded hero — matches the /aicochub landing hero: a centred
- * dark block with the page background showing on either side, rather than
- * a full-bleed edge-to-edge band. */
+/* Contained, rounded hero — a centred block with the page background showing
+ * on either side. Show & Tell default: solid Adobe red flood. */
 .session-header-hero {
+  --hd-red: #eb1000;
+
   position: relative;
   overflow: hidden;
   max-width: 1200px;
-  margin: 32px auto 0;
-  padding: 64px 32px 56px;
-  border-radius: 24px;
+  margin: 24px auto 0;
+  padding: 56px 32px 48px;
+  border-radius: 20px;
   color: #fff;
-  background:
-    radial-gradient(1100px 520px at 88% -10%, rgb(235 16 0 / 50%), transparent 62%),
-    radial-gradient(700px 500px at -8% 115%, rgb(99 60 255 / 22%), transparent 60%),
-    linear-gradient(135deg, #080d1a 0%, #100818 55%, #160609 100%);
+  background: var(--hd-red);
 }
-
-.session-header-hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image:
-    radial-gradient(circle at 20% 30%, rgb(255 255 255 / 6%) 0 1px, transparent 1px),
-    radial-gradient(circle at 70% 80%, rgb(255 255 255 / 5%) 0 1px, transparent 1px),
-    radial-gradient(circle at 90% 20%, rgb(255 255 255 / 5%) 0 1px, transparent 1px);
-  background-size: 80px 80px, 60px 60px, 120px 120px;
-  pointer-events: none;
-}
-
-/* The hero deliberately doesn't carry an image — pictures from the doc
- * flow in the body below, as normal article content. */
 
 .session-header-inner {
   position: relative;
@@ -58,10 +45,7 @@ main .session-header {
   margin: 0 auto;
 }
 
-/* breadcrumb
- * Explicit colours (no stacked opacity) so it stays legible on the dark
- * hero. The link colour is set with extra specificity to beat the theme's
- * `body.aicoc main a` red rule. */
+/* breadcrumb */
 .session-header-breadcrumb {
   font-size: 13px;
   letter-spacing: 0.04em;
@@ -72,18 +56,19 @@ main .session-header {
 }
 
 body.aicoc-session .session-header-breadcrumb a {
-  color: #ff6a5e;
+  color: #fff;
   opacity: 1;
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 body.aicoc-session .session-header-breadcrumb a:hover {
-  color: #ff8a80;
-  text-decoration: underline;
+  color: #fff;
+  opacity: 0.85;
 }
 
-.session-header-breadcrumb-sep { color: rgb(255 255 255 / 45%); }
-.session-header-breadcrumb-current { color: rgb(255 255 255 / 80%); }
+.session-header-breadcrumb-sep { color: rgb(255 255 255 / 70%); }
+.session-header-breadcrumb-current { color: #fff; }
 
 /* pills */
 .session-header-pills {
@@ -94,30 +79,30 @@ body.aicoc-session .session-header-breadcrumb a:hover {
 }
 
 .session-header-pill {
-  background: rgb(255 255 255 / 14%);
-  border: 1px solid rgb(255 255 255 / 18%);
+  background: transparent;
+  border: 1px solid rgb(255 255 255 / 70%);
   color: #fff;
   padding: 6px 14px;
   border-radius: 999px;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  backdrop-filter: blur(6px);
 }
 
+/* The format pill is the emphasis chip: solid white on the red flood. */
 .session-header-pill-format {
-  background: rgb(235 16 0 / 18%);
-  border-color: rgb(235 16 0 / 35%);
-  color: rgb(255 150 140 / 95%);
+  background: #fff;
+  border-color: #fff;
+  color: var(--hd-red);
 }
 
 /* title */
 main .session-header h1.session-header-title {
-  font-size: clamp(32px, 5vw, 52px);
-  line-height: 1.08;
-  font-weight: 800;
-  letter-spacing: -0.02em;
+  font-size: clamp(34px, 5vw, 54px);
+  line-height: 1.02;
+  font-weight: 900;
+  letter-spacing: -0.025em;
   margin: 0 0 18px;
   color: #fff;
   max-width: 900px;
@@ -127,7 +112,6 @@ main .session-header h1.session-header-title {
 .session-header-description {
   font-size: 17px;
   line-height: 1.55;
-  opacity: 0.88;
   max-width: 760px;
   margin: 0 0 26px;
   color: #fff;
@@ -140,8 +124,8 @@ main .session-header h1.session-header-title {
   flex-wrap: wrap;
   align-items: center;
   font-size: 14px;
-  opacity: 0.92;
   margin-bottom: 30px;
+  color: #fff;
 }
 
 .session-header-meta-item {
@@ -153,7 +137,6 @@ main .session-header h1.session-header-title {
 .session-header-meta-item svg,
 .session-header-meta-item .icon svg {
   flex-shrink: 0;
-  opacity: 0.85;
   width: 16px;
   height: 16px;
 }
@@ -185,8 +168,7 @@ main .session-header h1.session-header-title {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: rgb(235 16 0 / 25%);
-  border-color: rgb(235 16 0 / 35%);
+  background: transparent;
   color: #fff;
   font-size: 11px;
   font-weight: 700;
@@ -194,7 +176,7 @@ main .session-header h1.session-header-title {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid rgb(255 255 255 / 40%);
+  border: 2px solid #fff;
   margin-left: -8px;
 }
 
@@ -218,63 +200,113 @@ main .session-header .btn {
   cursor: pointer;
   border: 1px solid transparent;
   text-decoration: none;
-  transition: transform 0.1s, box-shadow 0.15s;
+  transition: transform 0.1s, box-shadow 0.15s, background 0.15s, color 0.15s;
 }
 
 main .session-header .btn:hover { transform: translateY(-1px); text-decoration: none; }
 
+/* On the red flood: primary = solid white, secondary/tertiary = white outline. */
 main .session-header .btn-primary {
   background: #fff;
-  color: #0b0b0d;
-  box-shadow: 0 8px 28px rgb(0 0 0 / 25%);
+  color: var(--hd-red);
+  box-shadow: 0 8px 28px rgb(0 0 0 / 20%);
 }
 
-main .session-header .btn-secondary {
-  background: rgb(255 255 255 / 10%);
-  color: #fff;
-  border-color: rgb(255 255 255 / 30%);
-  backdrop-filter: blur(6px);
-}
-
+main .session-header .btn-secondary,
 main .session-header .btn-tertiary {
   background: transparent;
   color: #fff;
-  border-color: rgb(255 255 255 / 30%);
+  border-color: #fff;
+}
+
+main .session-header .btn-secondary:hover,
+main .session-header .btn-tertiary:hover {
+  background: #fff;
+  color: var(--hd-red);
 }
 
 /* ── DESKTOP ───────────────────────────────────────────────────────────── */
 @media (min-width: 960px) {
   .session-header-hero {
-    padding: 80px 48px 64px;
+    padding: 72px 48px 60px;
   }
 }
 
-/* ── Brownbag variant (blue) ──────────────────────────────────────────────
- * AI Assisted Brownbag sessions get a blue gradient hero instead of red.
- */
-/* stylelint-disable selector-class-pattern */
+/* ── Brownbag variant — white hero, black text, red accents ──────────────── */
+/* stylelint-disable selector-class-pattern, no-descending-specificity */
 .session-header-hero--brownbag {
-  background:
-    radial-gradient(1100px 520px at 88% -10%, rgb(2 101 220 / 50%), transparent 62%),
-    radial-gradient(700px 500px at -8% 115%, rgb(99 60 255 / 22%), transparent 60%),
-    linear-gradient(135deg, #080d1a 0%, #060d1a 55%, #071426 100%);
+  background: #fff;
+  color: #000;
+  border: 1px solid var(--aicoc-border, #e5e5e7);
 }
 
+.session-header-hero--brownbag .session-header-pill {
+  border-color: var(--hd-red);
+  color: var(--hd-red);
+}
+
+/* On white, the format pill becomes the red-outline emphasis chip. */
 .session-header-hero--brownbag .session-header-pill-format {
-  background: rgb(2 101 220 / 18%);
-  border-color: rgb(2 101 220 / 35%);
-  color: rgb(100 180 250 / 95%);
+  background: #fff;
+  border-color: var(--hd-red);
+  color: var(--hd-red);
 }
 
-.session-header-hero--brownbag .session-header-breadcrumb a {
-  color: #6db3f2;
+body.aicoc-session .session-header-hero--brownbag .session-header-breadcrumb a {
+  color: var(--hd-red);
+  text-decoration: none;
 }
 
-.session-header-hero--brownbag .session-header-breadcrumb a:hover {
-  color: #9ecef7;
+body.aicoc-session .session-header-hero--brownbag .session-header-breadcrumb a:hover {
+  color: #b30c00;
+  text-decoration: underline;
 }
 
-.session-header-hero--brownbag .session-header-presenter-avatar {
-  background: linear-gradient(135deg, #0054B6, #0265DC);
+.session-header-hero--brownbag .session-header-breadcrumb-sep { color: #8e8e93; }
+.session-header-hero--brownbag .session-header-breadcrumb-current { color: #2c2c2e; }
+
+.session-header-hero--brownbag h1.session-header-title { color: #000; }
+.session-header-hero--brownbag .session-header-description { color: #2c2c2e; }
+.session-header-hero--brownbag .session-header-meta-row-inline { color: #2c2c2e; }
+
+.session-header-hero--brownbag .session-header-avatar {
+  background: transparent;
+  color: var(--hd-red);
+  border-color: var(--hd-red);
 }
-/* stylelint-enable selector-class-pattern */
+
+/* Buttons on white: primary = solid red, secondary/tertiary = red outline. */
+.session-header-hero--brownbag .btn-primary {
+  background: var(--hd-red);
+  color: #fff;
+}
+
+.session-header-hero--brownbag .btn-secondary,
+.session-header-hero--brownbag .btn-tertiary {
+  background: #fff;
+  color: var(--hd-red);
+  border-color: var(--hd-red);
+}
+
+.session-header-hero--brownbag .btn-secondary:hover,
+.session-header-hero--brownbag .btn-tertiary:hover {
+  background: var(--hd-red);
+  color: #fff;
+}
+
+/* ── Dark mode (true black) ──────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  .session-header-hero--brownbag {
+    background: #141414;
+    color: #fff;
+    border-color: #2a2a2a;
+  }
+
+  .session-header-hero--brownbag h1.session-header-title,
+  .session-header-hero--brownbag .session-header-description,
+  .session-header-hero--brownbag .session-header-meta-row-inline,
+  .session-header-hero--brownbag .session-header-breadcrumb-current {
+    color: #fff;
+  }
+}
+/* stylelint-enable selector-class-pattern, no-descending-specificity */

--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -86,72 +86,54 @@ body.aicoc main a:hover { color: var(--aicoc-accent-3); }
 /* stylelint-disable-next-line no-descending-specificity */
 body.aicoc-hub main > div:first-of-type {
   position: relative;
-  overflow: hidden;
 
-  /* Contained hero, not full-bleed — gives the page bg breathing room
-   * around a centered dark block, instead of dark edge-to-edge. */
+  /* Contained, centred header. NOTE: when the author omits the "---"
+   * separator the session-feed lives in THIS same section, so the background
+   * here sits behind the cards too — keep it the page colour and express the
+   * brand through type + the red eyebrow, not a flood that would tint the
+   * whole feed. (Adobe brand: simple red/black/white, no tones/transparencies,
+   * avoid dark palettes.) */
   max-width: 1200px;
-  margin: 32px auto 0;
-  padding: 40px 32px 36px;
-  border-radius: 24px;
-  color: #fff;
+  margin: 8px auto 0;
+  padding: 56px 32px 8px;
+  color: var(--aicoc-ink);
   text-align: center;
-  background:
-    radial-gradient(ellipse 900px 500px at 15% -20%, rgb(99 60 255 / 20%), transparent 65%),
-    radial-gradient(ellipse 700px 500px at 90% 120%, rgb(2 101 220 / 16%), transparent 60%),
-    radial-gradient(ellipse 600px 400px at 88% -10%, rgb(235 16 0 / 35%), transparent 55%),
-    linear-gradient(to bottom, #080d1a 0%, #0c0912 100%);
-}
-
-body.aicoc-hub main > div:first-of-type::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image:
-    radial-gradient(circle at 20% 30%, rgb(255 255 255 / 6%) 0 1px, transparent 1px),
-    radial-gradient(circle at 70% 80%, rgb(255 255 255 / 5%) 0 1px, transparent 1px),
-    radial-gradient(circle at 90% 20%, rgb(255 255 255 / 5%) 0 1px, transparent 1px);
-  background-size: 80px 80px, 60px 60px, 120px 120px;
-  pointer-events: none;
+  background: transparent;
 }
 
 body.aicoc-hub main > div:first-of-type > * {
   position: relative;
   z-index: 1;
-  max-width: 880px;
+  max-width: 820px;
   margin-left: auto;
   margin-right: auto;
   text-align: center;
 }
 
-/* Title */
+/* Title — solid black, Adobe Clean weight + tight tracking (brand: -20). */
 body.aicoc-hub main > div:first-of-type h1 {
-  font-size: clamp(36px, 6vw, 64px);
-  line-height: 1.08;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  margin: 0 0 18px;
-  background: linear-gradient(135deg, #fff 40%, rgb(180 195 255 / 85%) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-size: clamp(40px, 6.5vw, 68px);
+  line-height: 0.98;
+  font-weight: 900;
+  letter-spacing: -0.025em;
+  margin: 0 0 20px;
+  color: #000;
 }
 
-/* "Eyebrow" pill above the H1 — if author writes a small paragraph BEFORE
- * the H1, treat it as an eyebrow. */
+/* "Eyebrow" pill above the H1 — solid Adobe red, white text. */
 body.aicoc-hub main > div:first-of-type > p:first-child {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin: 0 auto 18px;
-  padding: 5px 14px;
+  margin: 0 auto 20px;
+  padding: 6px 14px;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgb(255 255 255 / 55%);
-  background: rgb(255 255 255 / 6%);
-  border: 1px solid rgb(255 255 255 / 12%);
+  color: #fff;
+  background: var(--aicoc-accent-1);
+  border: none;
   border-radius: 999px;
 }
 
@@ -164,7 +146,7 @@ body.aicoc-hub main > div:first-of-type > p:first-child {
 body.aicoc-hub main > div:first-of-type > p {
   font-size: clamp(15px, 1.8vw, 19px);
   line-height: 1.55;
-  color: rgb(255 255 255 / 88%);
+  color: var(--aicoc-ink-2);
   margin: 0 auto 18px;
   max-width: 720px;
 }
@@ -181,12 +163,14 @@ body.aicoc-hub main hr {
 
 /* When the author omits the "---" separator, the H1 + tagline + session-feed
  * all land in ONE section that also contains the (hidden) hr. That section is
- * the hero, so it must stay horizontally centred — use `0 auto`, not `0`, or
- * the centring margins collapse and the whole 1200px box pins to the left. */
+ * the hero, so it must stay horizontally centred (margin auto) — and we only
+ * collapse the vertical margin EDS adds, leaving the hero's own padding intact
+ * so the heading keeps its breathing room. */
+/* stylelint-disable-next-line no-descending-specificity */
 body.aicoc-hub main > div:has(hr) {
-  margin: 0 auto !important;
-  padding: 0 !important;
-  min-height: 0 !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  margin-top: 0 !important;
 }
 
 /* Any section in main BEYOND the first one (where the session-feed sits).
@@ -200,24 +184,25 @@ body.aicoc-hub main > div ~ div {
   background: transparent;
 }
 
-/* Dark mode: match the body bg to the hero's darkest gradient stop so the
- * hero's rounded corners blend seamlessly with the page instead of showing
- * lighter-grey corners.
- *
- * Belt-and-suspenders: also update the --aicoc-bg variable (used by any
- * remaining var() references), and explicitly set the same colour on <main>
- * so the page gutters are dark even if the body rule is overridden elsewhere
- * in the cascade. */
+/* Dark mode: black is a core Adobe colour (#000000), so we go true-black
+ * rather than a navy/somber palette (which the brand guidelines call out as
+ * "Not this"). White text, Adobe red accents carry through. */
 @media (prefers-color-scheme: dark) {
   body.aicoc {
-    --aicoc-bg: #080d1a;
-    --aicoc-card: #0d1325;
-    background-color: #080d1a;
+    --aicoc-bg: #000;
+    --aicoc-card: #141414;
+    --aicoc-ink: #fff;
+    --aicoc-ink-2: #d6d6d6;
+    --aicoc-border: #2a2a2a;
+
+    background-color: #000;
   }
 
   body.aicoc main {
-    background-color: #080d1a;
+    background-color: #000;
   }
+
+  body.aicoc-hub main > div:first-of-type h1 { color: #fff; }
 }
 
 /* Defensive: if the session-feed somehow ends up nested in the hero div


### PR DESCRIPTION
## Summary
Re-aligns the AI CoC hub and session pages with the **Adobe Brand Guidelines** (Jan 2025), while keeping the modern polish (rounded cards, soft shadows, hover motion).

The current design conflicts with several explicit brand rules — dark/somber navy palette, colour tints & transparencies, frosted glass, and gradient text are all called out as "Not this." This PR fixes that.

### Changes
- **Drop the navy base, gradient text, frosted pills, and all tints/transparencies.**
- **Hub hero:** white background, solid black headline (tight tracking, brand -20), solid Adobe red `#EB1000` eyebrow pill. (The feed shares the hero section, so the hero stays light rather than flooding the whole column.)
- **Cards & session heroes:** Adobe red used generously, with format differentiation by **red fill vs red outline** — Show & Tell = red flood + red-fill label/avatar; Brownbag = white + red-outline label/avatar. Replaces the off-brand blue.
- **Dark mode:** true black `#000` (a core brand colour) instead of navy.

### Preview
`https://feat-brand-aligned-redesign--inside-aem--adobe.aem.page/en/aicochub`
and a session page under `/en/aicoc/...`

### Test plan
- [ ] Review hub + a Show & Tell and a Brownbag session page on the preview
- [ ] Merge, then Sidekick **Preview → Publish** on the affected pages

> Note: kept Adobe Clean weights to whatever the site already loads; if Adobe Clean isn't licensed on this domain we can wire it up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)