### PR TITLE
fix: center the session card grid

### DIFF
--- a/blocks/session-feed/session-feed.css
+++ b/blocks/session-feed/session-feed.css
@@ -104,12 +104,13 @@ main .session-feed {
 
 /* auto-fill + a capped column width keeps each card a sensible size no
  * matter how many sessions there are — a single card no longer stretches
- * to fill a whole third of the page. justify-content: start packs the
- * cards to the left instead of spreading them. */
+ * to fill a whole third of the page. justify-content: center keeps the
+ * column block centred so leftover track space is split evenly on both
+ * sides instead of pooling on the right. */
 .session-feed-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 340px));
-  justify-content: start;
+  justify-content: center;
   gap: 24px;
 
   /* Each card sizes to its own content; no vertical stretching to match


### PR DESCRIPTION
## Summary
The card grid used `justify-content: start`, which packed the auto-fill columns to the left and let the leftover track space pool on the right — so the cards sat slightly left of center under the hero.

Switching to `justify-content: center` splits that leftover space evenly on both sides, centering the grid.

## Test plan
- [ ] Merge, then Sidekick **Preview → Publish** on `/en/aicochub`
- [ ] Card grid is horizontally centered under the hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)