### PR TITLE
feat: size and tighten the hub hero subhead (H2)

### DIFF
--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -116,8 +116,20 @@ body.aicoc-hub main > div:first-of-type h1 {
   line-height: 0.98;
   font-weight: 900;
   letter-spacing: -0.025em;
-  margin: 0 0 20px;
+  margin: 0 0 14px;
   color: #000;
+}
+
+/* Subhead (H2) under the headline — a touch larger than the tagline, and
+ * pulled up close to the H1 (EDS adds margin-top: 48px to headings, which
+ * leaves an oversized gap here). */
+body.aicoc-hub main > div:first-of-type h2 {
+  font-size: clamp(22px, 2.8vw, 30px);
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--aicoc-ink);
+  margin: 0 0 16px;
 }
 
 /* "Eyebrow" pill above the H1 — solid Adobe red, white text. */


### PR DESCRIPTION
## Summary
Keeps the H1 ("Every AI Session. One Place.") the same size, makes the H2 ("AI Community of Communities (AI CoC)") a little larger, and closes the big gap between them.

The gap came from EDS's default `margin-top: 48px` on headings; this adds a hub-hero-specific H2 rule with a tighter margin and a subhead size (`clamp(22px, 2.8vw, 30px)`).

## Test plan
- [ ] Merge, then Sidekick **Preview → Publish** on `/en/aicochub`
- [ ] H1 unchanged, H2 slightly bigger and sitting closer beneath it

🤖 Generated with [Claude Code](https://claude.com/claude-code)