### PR TITLE
feat: bump hub hero subhead (H2) to 35px

### DIFF
--- a/styles/aicoc.css
+++ b/styles/aicoc.css
@@ -124,7 +124,7 @@ body.aicoc-hub main > div:first-of-type h1 {
  * pulled up close to the H1 (EDS adds margin-top: 48px to headings, which
  * leaves an oversized gap here). */
 body.aicoc-hub main > div:first-of-type h2 {
-  font-size: clamp(22px, 2.8vw, 30px);
+  font-size: clamp(26px, 3.2vw, 35px);
   line-height: 1.2;
   font-weight: 700;
   letter-spacing: -0.01em;


### PR DESCRIPTION
## Summary
Increases the hub hero H2 ("AI Community of Communities (AI CoC)") to a 35px cap (`clamp(26px, 3.2vw, 35px)`), up from the previous 30px.

## Test plan
- [ ] Merge, then Sidekick **Preview → Publish** on `/en/aicochub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)