### PR TITLE
feat: add Show & Tell / Brownbag format filter

### DIFF
--- a/blocks/session-feed/session-feed.css
+++ b/blocks/session-feed/session-feed.css
@@ -22,9 +22,9 @@ main .session-feed {
 
 @media (min-width: 720px) {
   .session-feed-controls {
-    /* Search + presenter sit on one row; count is on a second row, centered
-     * across the full width. */
-    grid-template-columns: 1fr 220px;
+    /* Search (wide) + presenter + format sit on one row; count is on a second
+     * row, centered across the full width. */
+    grid-template-columns: 1fr 200px 180px;
     align-items: center;
   }
 }
@@ -52,7 +52,7 @@ main .session-feed {
  * Vertical centring is done with matching top/bottom padding and a
  * consistent total height across both controls. */
 .session-feed-search input,
-.session-feed-presenter {
+.session-feed-select {
   box-sizing: border-box;
   width: 100%;
   min-height: 44px;
@@ -75,7 +75,7 @@ main .session-feed {
 .session-feed-search input::placeholder { color: #8a8a90; }
 
 /* Custom chevron for the native <select> so it lines up with the inputs. */
-.session-feed-presenter {
+.session-feed-select {
   padding-right: 38px;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path fill='%236e6e73' d='M6 8 0 0h12z'/></svg>");
   background-repeat: no-repeat;
@@ -84,7 +84,7 @@ main .session-feed {
 }
 
 .session-feed-search input:focus,
-.session-feed-presenter:focus {
+.session-feed-select:focus {
   outline: none;
   border-color: #EB1000;
   box-shadow: 0 0 0 3px rgb(235 16 0 / 12%);

--- a/blocks/session-feed/session-feed.js
+++ b/blocks/session-feed/session-feed.js
@@ -79,10 +79,21 @@ async function fetchAllSessions() {
 // Filtering
 // ─────────────────────────────────────────────────────────────────────────
 
-function applyFilters(sessions, { q, presenter }) {
+/**
+ * Session format lives in the title (there are no usable tags): titles read
+ * like "[AI CoC] AI Assisted Brownbag - …" or "[AI CoC] Show & Tell - …".
+ */
+function sessionFormat(s) {
+  if (/brownbag/i.test(s.title)) return 'Brownbag';
+  if (/show\s*(?:&|and)\s*tell/i.test(s.title)) return 'Show & Tell';
+  return '';
+}
+
+function applyFilters(sessions, { q, presenter, format }) {
   const needle = (q || '').toLowerCase().trim();
   const presenterNeedle = (presenter || '').toLowerCase().trim();
   return sessions.filter((s) => {
+    if (format && sessionFormat(s) !== format) return false;
     if (presenterNeedle && !s.presenter.toLowerCase().includes(presenterNeedle)) return false;
     if (needle) {
       const hay = `${s.title} ${s.description} ${s.presenter}`.toLowerCase();
@@ -106,13 +117,18 @@ function uniquePresenters(sessions) {
 
 function readUrlState() {
   const params = new URLSearchParams(window.location.search);
-  return { q: params.get('q') || '', presenter: params.get('presenter') || '' };
+  return {
+    q: params.get('q') || '',
+    presenter: params.get('presenter') || '',
+    format: params.get('format') || '',
+  };
 }
 
 function writeUrlState(state) {
   const url = new URL(window.location.href);
   if (state.q) url.searchParams.set('q', state.q); else url.searchParams.delete('q');
   if (state.presenter) url.searchParams.set('presenter', state.presenter); else url.searchParams.delete('presenter');
+  if (state.format) url.searchParams.set('format', state.format); else url.searchParams.delete('format');
   window.history.replaceState({}, '', url);
 }
 
@@ -180,14 +196,31 @@ export default async function decorate(block) {
 
   // Presenter dropdown (populated after fetch).
   const presenterSelect = document.createElement('select');
-  presenterSelect.className = 'session-feed-presenter';
+  presenterSelect.className = 'session-feed-presenter session-feed-select';
   presenterSelect.setAttribute('aria-label', 'Filter by presenter');
+
+  // Format dropdown (Show & Tell / Brownbag).
+  const formatSelect = document.createElement('select');
+  formatSelect.className = 'session-feed-format session-feed-select';
+  formatSelect.setAttribute('aria-label', 'Filter by format');
+  [
+    ['', 'All formats'],
+    ['Show & Tell', 'Show & Tell'],
+    ['Brownbag', 'Brownbag'],
+  ].forEach(([value, label]) => {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = label;
+    if (value === state.format) opt.selected = true;
+    formatSelect.append(opt);
+  });
 
   // Result count badge.
   const count = document.createElement('span');
   count.className = 'session-feed-count';
 
-  controls.append(searchWrap, presenterSelect, count);
+  // Order: search (left, wide) · presenter · format.
+  controls.append(searchWrap, presenterSelect, formatSelect, count);
   block.append(controls);
 
   // ── Grid ──
@@ -280,6 +313,12 @@ export default async function decorate(block) {
 
   presenterSelect.addEventListener('change', () => {
     state.presenter = presenterSelect.value;
+    writeUrlState(state);
+    refilter();
+  });
+
+  formatSelect.addEventListener('change', () => {
+    state.format = formatSelect.value;
     writeUrlState(state);
     refilter();
   });


### PR DESCRIPTION
## Summary
Adds a second dropdown next to the presenter filter so sessions can be filtered by **format** (Show & Tell / Brownbag).

- Format is derived from the **session title** (e.g. "… AI Assisted Brownbag …" / "… Show & Tell …") since there are no usable tags.
- Controls are reordered to: **search (wide) · presenter · format**.
- The selection syncs to a `?format=` URL param (shareable / back-button friendly), matching the existing `q` and `presenter` params.

## Test plan
- [ ] Merge, then Sidekick **Preview → Publish** on `/en/aicochub`
- [ ] Selecting "Brownbag" shows only brownbag cards; "Show & Tell" only those; "All formats" clears it
- [ ] Works combined with the presenter filter + search

🤖 Generated with [Claude Code](https://claude.com/claude-code)