### PR TITLE
feat: show clap counts on article feed cards

### DIFF
--- a/blocks/article-feed/article-feed.css
+++ b/blocks/article-feed/article-feed.css
@@ -46,6 +46,18 @@ main .article-feed .article-card:hover {
   content: '· ';
 }
 
+/* Clap count badge */
+.card-claps {
+  display: inline-block;
+  font-size: var(--body-font-size-xxs);
+  color: var(--color-gray-500);
+  margin-left: 8px;
+}
+
+.card-claps::before {
+  content: '· ';
+}
+
 @media (min-width: 600px) {
   main .article-cards {
     padding-left: 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -772,8 +772,25 @@ export function buildArticleCard(article, type = 'article', eager = false) {
       </p>
       <h3>${title}</h3>
       <p class="${type}-card-description">${description}</p>
-      <p class="${type}-card-date">${formatLocalCardDate(date)}<span class="${type}-card-read-time">${readTime}</span></p>
+      <p class="${type}-card-date">${formatLocalCardDate(date)}<span class="${type}-card-read-time">${readTime}</span><span class="${type}-card-claps card-claps" hidden></span></p>
     </div>`;
+
+  // Asynchronously fetch the clap count for this article and show it on the card.
+  // Uses the same applause service the article-page clap button writes to, keyed
+  // on the article path (window.location.pathname on the article page === card href).
+  const clapsEl = card.querySelector('.card-claps');
+  fetch(`https://applause.chabouis.fr/get-claps?url=${encodeURIComponent(path)}`)
+    .then((res) => (res.ok ? res.text() : null))
+    .then((text) => {
+      const count = parseInt(text, 10);
+      if (count > 0) {
+        clapsEl.textContent = `👏 ${count.toLocaleString()}`;
+        clapsEl.setAttribute('aria-label', `${count} claps`);
+        clapsEl.hidden = false;
+      }
+    })
+    .catch(() => { /* clap count is non-critical; ignore failures */ });
+
   return card;
 }
 


### PR DESCRIPTION
## What

Surfaces each article's **clap count** on its feed/preview card, so the applause numbers shown on the article page are also visible on the main pages (culture-tecture.adobe.com & re-think.adobe.com) and anywhere article cards are rendered.

## How

`buildArticleCard()` now renders a hidden clap badge in the card's date line, then **asynchronously** fetches the count from `applause.chabouis.fr` — the same service the article-page clap button writes to. The count is keyed on the article path, which is exactly the card's `href`, so cards show the same number as the article page.

- Fetch never blocks card rendering; failures are silently ignored (clap count is non-critical).
- Badge only appears when an article actually has claps (`count > 0`), to avoid a row of "👏 0" noise.
- Applies to every card type (main feed, featured, recommended) since they all go through `buildArticleCard`.

This is the same per-path lookup pattern already used by `/admin/claps-analytics.html` — the applause service only exposes per-URL counts (no bulk/aggregated endpoint), so there's no stored total to reuse.

## Files

- `scripts/scripts.js` — clap badge + async fetch in `buildArticleCard`
- `blocks/article-feed/article-feed.css` — `.card-claps` badge styling (matches the existing "min read" badge)

## Verification

- eslint + stylelint clean.
- Ran the exact added fetch/parse logic against the live applause API: a path with claps renders `👏 37`; paths without stay hidden. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)