### PR TITLE
style: enlarge clap badge 25% and add spacing from read time

### DIFF
--- a/blocks/article-feed/article-feed.css
+++ b/blocks/article-feed/article-feed.css
@@ -49,9 +49,9 @@ main .article-feed .article-card:hover {
 /* Clap count badge */
 .card-claps {
   display: inline-block;
-  font-size: var(--body-font-size-xxs);
+  font-size: calc(var(--body-font-size-xxs) * 1.25);
   color: var(--color-gray-500);
-  margin-left: 8px;
+  margin-left: 14px;
 }
 
 .card-claps::before {


### PR DESCRIPTION
Follow-up tweak to the clap counts shipped in #124.

On the feed cards the clap badge sat too close to "MIN READ" and read a touch small. This:

- Increases the badge font size by 25% (`calc(var(--body-font-size-xxs) * 1.25)`)
- Adds spacing from the read-time (`margin-left` 8px → 14px)

Single-file CSS change in `blocks/article-feed/article-feed.css`; stylelint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)