### PR TITLE
feat: expand articles dashboard with author/topic/cadence + RUM page views

### DIFF
--- a/admin/claps-analytics.html
+++ b/admin/claps-analytics.html
@@ -44,7 +44,7 @@
 
     .stats-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 20px;
       margin-bottom: 30px;
     }
@@ -58,25 +58,111 @@
     }
 
     .stat-card .number {
-      font-size: 3rem;
+      font-size: 2.6rem;
       font-weight: bold;
       color: #ffffff;
       margin-bottom: 10px;
     }
 
     .stat-card .label {
-      font-size: 1rem;
+      font-size: 0.95rem;
       color: #ecf0f1;
       text-transform: uppercase;
       letter-spacing: 1px;
     }
 
-    .table-container {
+    .panel {
       background: white;
       padding: 30px;
       border-radius: 12px;
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
       overflow-x: auto;
+      margin-bottom: 30px;
+    }
+
+    .panel h2 {
+      color: #333;
+      font-size: 1.4rem;
+      margin-bottom: 6px;
+    }
+
+    .panel .panel-hint {
+      color: #999;
+      font-size: 0.85rem;
+      margin-bottom: 20px;
+    }
+
+    .panels-2col {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+      gap: 30px;
+    }
+
+    /* RUM config bar */
+    .rum-config {
+      display: flex;
+      align-items: flex-end;
+      gap: 15px;
+      flex-wrap: wrap;
+    }
+
+    .rum-config .field {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+
+    .rum-config label {
+      font-size: 0.8rem;
+      color: #666;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .rum-config input,
+    .rum-config select {
+      padding: 10px 14px;
+      border: 2px solid #e0e0e0;
+      border-radius: 8px;
+      font-size: 0.95rem;
+    }
+
+    .rum-config input:focus,
+    .rum-config select:focus {
+      outline: none;
+      border-color: #667eea;
+    }
+
+    .btn {
+      padding: 11px 22px;
+      border: 2px solid #667eea;
+      background: #667eea;
+      color: white;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 0.95rem;
+      font-weight: 600;
+      transition: all 0.2s;
+    }
+
+    .btn:hover {
+      background: #5568d3;
+    }
+
+    .btn.secondary {
+      background: white;
+      color: #667eea;
+    }
+
+    .rum-status {
+      margin-top: 12px;
+      font-size: 0.9rem;
+      color: #666;
+    }
+
+    .rum-status.error {
+      color: #e74c3c;
     }
 
     .controls {
@@ -102,28 +188,6 @@
       border-color: #667eea;
     }
 
-    .filter-buttons {
-      display: flex;
-      gap: 10px;
-    }
-
-    .filter-btn {
-      padding: 10px 20px;
-      border: 2px solid #667eea;
-      background: white;
-      color: #667eea;
-      border-radius: 8px;
-      cursor: pointer;
-      font-size: 0.9rem;
-      font-weight: 600;
-      transition: all 0.3s;
-    }
-
-    .filter-btn:hover, .filter-btn.active {
-      background: #667eea;
-      color: white;
-    }
-
     table {
       width: 100%;
       border-collapse: collapse;
@@ -131,13 +195,18 @@
 
     th {
       background: #f8f9fa;
-      padding: 15px;
+      padding: 14px 12px;
       text-align: left;
       font-weight: 600;
       color: #333;
       border-bottom: 2px solid #e0e0e0;
       cursor: pointer;
       user-select: none;
+      white-space: nowrap;
+    }
+
+    th.numeric, td.numeric {
+      text-align: right;
     }
 
     th:hover {
@@ -152,8 +221,9 @@
     }
 
     td {
-      padding: 15px;
+      padding: 14px 12px;
       border-bottom: 1px solid #f0f0f0;
+      vertical-align: top;
     }
 
     tr:hover {
@@ -161,7 +231,6 @@
     }
 
     .claps-count {
-      font-size: 1.5rem;
       font-weight: bold;
       color: #667eea;
     }
@@ -169,13 +238,13 @@
     .article-title {
       color: #333;
       font-weight: 600;
-      font-size: 1.05rem;
+      font-size: 1.02rem;
     }
 
     .article-link {
       color: #1473E6;
       text-decoration: none;
-      font-size: 0.9rem;
+      font-size: 0.85rem;
       word-break: break-all;
     }
 
@@ -183,9 +252,54 @@
       text-decoration: underline;
     }
 
-    .article-date {
+    .muted {
       color: #999;
       font-size: 0.9rem;
+    }
+
+    .tag {
+      display: inline-block;
+      background: #eef0fb;
+      color: #4a57c9;
+      border-radius: 6px;
+      padding: 2px 8px;
+      font-size: 0.78rem;
+      margin: 2px 2px 0 0;
+    }
+
+    .bar-row {
+      display: grid;
+      grid-template-columns: 160px 1fr 70px;
+      align-items: center;
+      gap: 12px;
+      padding: 7px 0;
+      font-size: 0.92rem;
+    }
+
+    .bar-row .bar-label {
+      color: #333;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .bar-track {
+      background: #eef0fb;
+      border-radius: 6px;
+      height: 18px;
+      overflow: hidden;
+    }
+
+    .bar-fill {
+      background: #667eea;
+      height: 100%;
+      border-radius: 6px;
+    }
+
+    .bar-row .bar-value {
+      text-align: right;
+      color: #666;
+      font-weight: 600;
     }
 
     .loading {
@@ -210,10 +324,6 @@
       100% { transform: rotate(360deg); }
     }
 
-    .emoji {
-      font-size: 1.2rem;
-    }
-
     .no-results {
       text-align: center;
       padding: 40px;
@@ -222,26 +332,11 @@
     }
 
     @media (max-width: 768px) {
-      .header h1 {
-        font-size: 1.8rem;
-      }
-
-      .controls {
-        flex-direction: column;
-        align-items: stretch;
-      }
-
-      .search-box {
-        width: 100%;
-      }
-
-      table {
-        font-size: 0.9rem;
-      }
-
-      .claps-count {
-        font-size: 1.2rem;
-      }
+      .header h1 { font-size: 1.8rem; }
+      .controls { flex-direction: column; align-items: stretch; }
+      .search-box { width: 100%; }
+      table { font-size: 0.9rem; }
+      .bar-row { grid-template-columns: 110px 1fr 50px; }
     }
   </style>
 </head>
@@ -249,7 +344,7 @@
   <div class="container">
     <div class="header">
       <h1>📚 Articles Dashboard</h1>
-      <p>Browse and search all your blog articles</p>
+      <p>Engagement & publishing analytics for the blog</p>
     </div>
 
     <div class="stats-grid">
@@ -261,16 +356,55 @@
         <div class="number" id="totalClaps">-</div>
         <div class="label">Total Claps</div>
       </div>
+      <div class="stat-card">
+        <div class="number" id="avgClaps">-</div>
+        <div class="label">Avg Claps / Article</div>
+      </div>
+      <div class="stat-card">
+        <div class="number" id="totalViews">—</div>
+        <div class="label">Total Page Views</div>
+      </div>
+      <div class="stat-card">
+        <div class="number" id="totalAuthors">-</div>
+        <div class="label">Authors</div>
+      </div>
     </div>
 
-    <div class="table-container">
+    <!-- Page views (RUM) configuration -->
+    <div class="panel">
+      <h2>📈 Page views (AEM RUM)</h2>
+      <p class="panel-hint">
+        Real page-view data comes from AEM's built-in Real User Monitoring. It needs the domain's
+        <strong>RUM domainkey</strong> (a secret) &mdash; it is stored only in this browser (localStorage), never sent anywhere except the RUM API.
+        Views are weighted/sampled estimates.
+      </p>
+      <div class="rum-config">
+        <div class="field">
+          <label for="rumDomain">Domain</label>
+          <input type="text" id="rumDomain" style="width: 260px;">
+        </div>
+        <div class="field">
+          <label for="rumKey">Domainkey</label>
+          <input type="password" id="rumKey" placeholder="paste domainkey" style="width: 260px;">
+        </div>
+        <div class="field">
+          <label for="rumRange">Range</label>
+          <select id="rumRange">
+            <option value="7">Last 7 days</option>
+            <option value="30" selected>Last 30 days</option>
+            <option value="90">Last 90 days</option>
+          </select>
+        </div>
+        <button class="btn" id="loadRumBtn">Load page views</button>
+        <button class="btn secondary" id="forgetKeyBtn">Forget key</button>
+      </div>
+      <div class="rum-status" id="rumStatus"></div>
+    </div>
+
+    <!-- Main articles table -->
+    <div class="panel">
       <div class="controls">
         <input type="text" class="search-box" id="searchBox" placeholder="🔍 Search articles...">
-        <div class="filter-buttons">
-          <button class="filter-btn active" data-sort="date">Sort by Date</button>
-          <button class="filter-btn" data-sort="title">Sort by Title</button>
-          <button class="filter-btn" data-sort="totalClaps">Sort by Claps</button>
-        </div>
       </div>
 
       <div id="loading" class="loading">
@@ -281,317 +415,466 @@
       <table id="articlesTable" style="display: none;">
         <thead>
           <tr>
-            <th data-sort="title">Article Title<span class="sort-indicator"></span></th>
-            <th data-sort="path">Path<span class="sort-indicator"></span></th>
-            <th data-sort="date">Publication Date<span class="sort-indicator"></span></th>
-            <th data-sort="totalClaps">Total Claps<span class="sort-indicator"></span></th>
+            <th data-sort="title">Article<span class="sort-indicator"></span></th>
+            <th data-sort="author">Author<span class="sort-indicator"></span></th>
+            <th data-sort="date">Date<span class="sort-indicator"></span></th>
+            <th class="numeric" data-sort="totalClaps">Claps<span class="sort-indicator"></span></th>
+            <th class="numeric" data-sort="velocity">Claps/day<span class="sort-indicator"></span></th>
+            <th class="numeric" data-sort="views">Views<span class="sort-indicator"></span></th>
+            <th class="numeric" data-sort="engagement">Claps/1k views<span class="sort-indicator"></span></th>
           </tr>
         </thead>
-        <tbody id="tableBody">
-        </tbody>
+        <tbody id="tableBody"></tbody>
       </table>
 
       <div id="noResults" class="no-results" style="display: none;">
         No articles found matching your search.
       </div>
     </div>
+
+    <div class="panels-2col">
+      <div class="panel">
+        <h2>✍️ Top authors</h2>
+        <p class="panel-hint">By total claps across their articles</p>
+        <div id="authorBars"></div>
+      </div>
+      <div class="panel">
+        <h2>🏷️ Top topics</h2>
+        <p class="panel-hint">By total claps across tagged articles</p>
+        <div id="topicBars"></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>🗓️ Publishing cadence</h2>
+      <p class="panel-hint">Articles published per month</p>
+      <div id="cadenceBars"></div>
+    </div>
   </div>
 
   <script>
-    // Version: 9ba64ee - Fixed API response handling
     let articles = [];
     let currentSort = 'date';
     let sortDirection = 'desc';
+    let viewsLoaded = false;
 
-    // Fetch claps data for a single article
+    // ---------- Claps ----------
     async function fetchClapsForArticle(articlePath) {
       try {
         const apiUrl = `https://applause.chabouis.fr/get-claps?url=${encodeURIComponent(articlePath)}`;
-        console.log(`Fetching claps for: ${articlePath}`);
-        
         const response = await fetch(apiUrl);
-        
-        if (!response.ok) {
-          console.warn(`Failed to fetch claps for ${articlePath}: ${response.status}`);
-          return { totalClaps: 0, uniqueUsers: 0 };
-        }
-        
+        if (!response.ok) return 0;
         const data = await response.json();
-        console.log(`API response for ${articlePath}:`, data, 'Type:', typeof data);
-        
-        // The API returns just a number (total claps), not an object
-        if (typeof data === 'number') {
-          return {
-            totalClaps: data,
-            uniqueUsers: 0 // API doesn't provide unique users count
-          };
-        }
-        
-        // Fallback for object format
-        return {
-          totalClaps: data.claps || data || 0,
-          uniqueUsers: data.unique || 0
-        };
+        if (typeof data === 'number') return data;
+        return data.claps || data || 0;
       } catch (error) {
         console.error(`Error fetching claps for ${articlePath}:`, error);
-        return { totalClaps: 0, uniqueUsers: 0 };
+        return 0;
       }
     }
 
-    // Fetch blog articles from query-index
+    // ---------- Articles (query-index) ----------
+    function parseTags(raw) {
+      if (!raw) return [];
+      if (Array.isArray(raw)) return raw.filter(Boolean);
+      // query-index may store tags as a JSON array string or comma-separated
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) return parsed.filter(Boolean);
+      } catch (e) { /* not JSON */ }
+      return String(raw).split(',').map((t) => t.trim()).filter(Boolean);
+    }
+
     async function fetchArticles() {
       try {
-        console.log('Fetching /en/query-index.json...');
         const response = await fetch('/en/query-index.json');
-        console.log('Response status:', response.status);
-        
         if (!response.ok) {
-          console.error('Failed to fetch articles:', response.status, response.statusText);
+          console.error('Failed to fetch articles:', response.status);
           return [];
         }
-        
         const data = await response.json();
-        console.log('Raw data:', data);
-        console.log('Total entries:', data.data?.length);
-        
-        // Check what fields the first article has
-        if (data.data && data.data.length > 0) {
-          console.log('Sample article fields:', Object.keys(data.data[0]));
-          console.log('Sample article:', data.data[0]);
-        }
-        
-        // Try multiple possible date field names
-        const articles = data.data.filter(article => {
-          const hasDate = article['publication-date'] || article.date || article.publishDate || article.publicationDate;
-          return hasDate;
-        }).map(article => ({
-          ...article,
-          // Normalize the date field
-          date: article['publication-date'] || article.date || article.publishDate || article.publicationDate
+        return (data.data || []).map((article) => ({
+          title: article.title || '(untitled)',
+          path: (article.path || '').replace('.html', ''),
+          author: article.author || 'Unknown',
+          date: article.date || article['publication-date'] || article.lastModified || null,
+          description: article.description || '',
+          tags: parseTags(article.tags),
+          totalClaps: 0,
+          views: null,
         }));
-        
-        console.log(`Loaded ${articles.length} articles with dates`);
-        
-        // If no articles have dates, just return all articles
-        if (articles.length === 0) {
-          console.warn('No articles have date fields, returning all articles');
-          return data.data.map(article => ({
-            ...article,
-            date: article.lastModified || new Date().toISOString()
-          }));
-        }
-        
-        return articles;
       } catch (error) {
         console.error('Error fetching articles:', error);
         return [];
       }
     }
 
-    // Load all data
     async function loadData() {
-      console.log('Starting to load data...');
       const articlesData = await fetchArticles();
-      console.log(`Fetched ${articlesData.length} articles`);
-      
       if (articlesData.length === 0) {
         document.getElementById('loading').innerHTML = '<p style="color: #e74c3c;">⚠️ No articles found.</p>';
         return;
       }
-      
-      // Map articles without fetching claps initially
-      articles = articlesData.map(article => ({
-        title: article.title,
-        path: article.path.replace('.html', ''),
-        date: article.date || article.lastModified || 'N/A',
-        description: article.description || '',
-        totalClaps: 0,
-        uniqueUsers: 0
-      }));
-
-      console.log(`Loaded ${articles.length} articles`);
+      articles = articlesData;
       updateStats();
       renderTable();
-      
+      renderAuthorBars();
+      renderTopicBars();
+      renderCadenceBars();
+
       document.getElementById('loading').style.display = 'none';
       document.getElementById('articlesTable').style.display = 'table';
 
-      // Fetch claps data for all articles with progress indicator
       await fetchAllClaps();
     }
 
-    // Fetch claps for all articles with progress tracking
     async function fetchAllClaps() {
       const loadingEl = document.getElementById('loading');
       loadingEl.style.display = 'block';
       loadingEl.innerHTML = '<div class="spinner"></div><p>Loading claps data... <span id="clapsProgress">0/' + articles.length + '</span></p>';
-      
+
       let completedCount = 0;
       const progressEl = document.getElementById('clapsProgress');
-      
-      // Fetch claps in batches to avoid overwhelming the API
       const batchSize = 5;
       for (let i = 0; i < articles.length; i += batchSize) {
         const batch = articles.slice(i, i + batchSize);
-        
+        // eslint-disable-next-line no-await-in-loop
         await Promise.all(batch.map(async (article) => {
-          const clapsData = await fetchClapsForArticle(article.path);
-          article.totalClaps = clapsData.totalClaps;
-          article.uniqueUsers = clapsData.uniqueUsers;
-          completedCount++;
-          if (progressEl) {
-            progressEl.textContent = `${completedCount}/${articles.length}`;
-          }
+          article.totalClaps = await fetchClapsForArticle(article.path);
+          completedCount += 1;
+          if (progressEl) progressEl.textContent = `${completedCount}/${articles.length}`;
         }));
-        
-        // Update display after each batch
         updateStats();
         renderTable();
+        renderAuthorBars();
+        renderTopicBars();
       }
-      
       loadingEl.style.display = 'none';
-      console.log('Finished loading all claps data');
     }
 
-    // Update statistics
-    function updateStats() {
-      const totalArticles = articles.length;
-      const totalClaps = articles.reduce((sum, article) => sum + (article.totalClaps || 0), 0);
-      
-      document.getElementById('totalArticles').textContent = totalArticles.toLocaleString();
-      document.getElementById('totalClaps').textContent = totalClaps.toLocaleString();
+    // ---------- Page views (AEM RUM) ----------
+    function rumUrl(domain, year, month, day, key) {
+      return `https://rum.hlx.page/bundles/${domain}/${year}/${month}/${day}?domainkey=${encodeURIComponent(key)}`;
     }
 
-    // Sort articles
-    function sortArticles(sortBy) {
-      const direction = currentSort === sortBy && sortDirection === 'desc' ? 'asc' : 'desc';
-      sortDirection = direction;
-      currentSort = sortBy;
+    async function fetchRumDay(domain, key, d) {
+      const url = rumUrl(domain, d.getFullYear(), d.getMonth() + 1, d.getDate(), key);
+      const res = await fetch(url);
+      if (!res.ok) {
+        const err = new Error(`RUM ${res.status}`);
+        err.status = res.status;
+        throw err;
+      }
+      const json = await res.json();
+      return json.rumBundles || [];
+    }
 
-      articles.sort((a, b) => {
-        let aVal = a[sortBy];
-        let bVal = b[sortBy];
+    function pathFromUrl(u) {
+      try {
+        return new URL(u).pathname.replace('.html', '').replace(/\/$/, '') || '/';
+      } catch (e) {
+        return null;
+      }
+    }
 
-        if (sortBy === 'date') {
-          return direction === 'desc' 
-            ? new Date(bVal) - new Date(aVal)
-            : new Date(aVal) - new Date(bVal);
-        } else if (sortBy === 'totalClaps' || sortBy === 'uniqueUsers') {
-          // Numeric sorting for claps and users
-          const aNum = aVal || 0;
-          const bNum = bVal || 0;
-          return direction === 'desc'
-            ? bNum - aNum
-            : aNum - bNum;
-        } else {
-          // String sorting for title and path
-          return direction === 'desc'
-            ? bVal.localeCompare(aVal)
-            : aVal.localeCompare(bVal);
+    async function loadPageViews() {
+      const statusEl = document.getElementById('rumStatus');
+      const domain = document.getElementById('rumDomain').value.trim();
+      const key = document.getElementById('rumKey').value.trim();
+      const days = parseInt(document.getElementById('rumRange').value, 10);
+
+      if (!domain || !key) {
+        statusEl.className = 'rum-status error';
+        statusEl.textContent = 'Please provide both a domain and a domainkey.';
+        return;
+      }
+      localStorage.setItem('rum-domainkey', key);
+      localStorage.setItem('rum-domain', domain);
+
+      statusEl.className = 'rum-status';
+      const viewsByPath = {};
+      let processed = 0;
+      let failed = 0;
+      const today = new Date();
+
+      // Build the list of days to query
+      const dayList = [];
+      for (let i = 0; i < days; i += 1) {
+        const d = new Date(today);
+        d.setDate(today.getDate() - i);
+        dayList.push(d);
+      }
+
+      // Query in small batches to be gentle on the API
+      const batchSize = 6;
+      for (let i = 0; i < dayList.length; i += batchSize) {
+        const batch = dayList.slice(i, i + batchSize);
+        statusEl.textContent = `Loading page views… ${processed}/${dayList.length} days`;
+        // eslint-disable-next-line no-await-in-loop
+        const results = await Promise.allSettled(batch.map((d) => fetchRumDay(domain, key, d)));
+        results.forEach((r) => {
+          processed += 1;
+          if (r.status === 'rejected') {
+            failed += 1;
+            if (r.reason && (r.reason.status === 401 || r.reason.status === 403)) {
+              statusEl.className = 'rum-status error';
+              statusEl.textContent = 'Invalid domainkey (401/403). Double-check the key for this domain.';
+            }
+            return;
+          }
+          r.value.forEach((bundle) => {
+            const p = pathFromUrl(bundle.url);
+            if (!p) return;
+            viewsByPath[p] = (viewsByPath[p] || 0) + (bundle.weight || 1);
+          });
+        });
+      }
+
+      // Stop if the key was clearly rejected for every request
+      if (failed === dayList.length) {
+        if (!statusEl.textContent.includes('domainkey')) {
+          statusEl.className = 'rum-status error';
+          statusEl.textContent = 'Could not load RUM data — all requests failed. Check the domain and domainkey.';
         }
-      });
-
-      renderTable();
-    }
-
-    // Render table
-    function renderTable(filteredArticles = articles) {
-      const tbody = document.getElementById('tableBody');
-      tbody.innerHTML = '';
-
-      if (filteredArticles.length === 0) {
-        document.getElementById('articlesTable').style.display = 'none';
-        document.getElementById('noResults').style.display = 'block';
         return;
       }
 
-      document.getElementById('articlesTable').style.display = 'table';
-      document.getElementById('noResults').style.display = 'none';
-
-      filteredArticles.forEach(article => {
-        const row = document.createElement('tr');
-        const clapsClass = (article.totalClaps || 0) > 10 ? 'claps-count' : '';
-        row.innerHTML = `
-          <td><div class="article-title">${article.title}</div></td>
-          <td><a href="${article.path}" target="_blank" class="article-link">${article.path}</a></td>
-          <td><span class="article-date">${formatDate(article.date)}</span></td>
-          <td><span class="${clapsClass}">${article.totalClaps || 0}</span></td>
-        `;
-        tbody.appendChild(row);
+      // Attach views to articles
+      let totalSiteViews = 0;
+      Object.values(viewsByPath).forEach((v) => { totalSiteViews += v; });
+      articles.forEach((a) => {
+        const key2 = a.path.replace(/\/$/, '') || '/';
+        a.views = viewsByPath[key2] || 0;
       });
+      viewsLoaded = true;
 
-      // Update sort indicators
-      document.querySelectorAll('th .sort-indicator').forEach(indicator => {
-        indicator.textContent = '';
-      });
-      const activeTh = document.querySelector(`th[data-sort="${currentSort}"]`);
-      if (activeTh) {
-        const indicator = activeTh.querySelector('.sort-indicator');
-        if (indicator) {
-          indicator.textContent = sortDirection === 'desc' ? '▼' : '▲';
-        }
-      }
+      document.getElementById('totalViews').textContent = Math.round(totalSiteViews).toLocaleString();
+      const note = failed > 0 ? ` (${failed} day(s) failed)` : '';
+      statusEl.className = 'rum-status';
+      statusEl.textContent = `Loaded ~${Math.round(totalSiteViews).toLocaleString()} page views across ${days} days${note}. Views are sampled estimates.`;
+      renderTable();
     }
 
-    // Format date
+    // ---------- Stats ----------
+    function median(nums) {
+      if (nums.length === 0) return 0;
+      const sorted = [...nums].sort((a, b) => a - b);
+      const mid = Math.floor(sorted.length / 2);
+      return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    }
+
+    function daysSince(date) {
+      const t = new Date(date).getTime();
+      if (Number.isNaN(t)) return null;
+      return Math.max(1, (Date.now() - t) / 86400000);
+    }
+
+    function velocityOf(article) {
+      const d = daysSince(article.date);
+      if (!d) return 0;
+      return article.totalClaps / d;
+    }
+
+    function engagementOf(article) {
+      if (!article.views || article.views <= 0) return null;
+      return (article.totalClaps / article.views) * 1000;
+    }
+
+    function updateStats() {
+      const totalArticles = articles.length;
+      const totalClaps = articles.reduce((sum, a) => sum + (a.totalClaps || 0), 0);
+      const avg = totalArticles ? totalClaps / totalArticles : 0;
+      const med = median(articles.map((a) => a.totalClaps || 0));
+      const authors = new Set(articles.map((a) => a.author).filter((x) => x && x !== 'Unknown'));
+
+      document.getElementById('totalArticles').textContent = totalArticles.toLocaleString();
+      document.getElementById('totalClaps').textContent = totalClaps.toLocaleString();
+      document.getElementById('avgClaps').textContent = `${avg.toFixed(1)} (med ${med})`;
+      document.getElementById('totalAuthors').textContent = authors.size.toLocaleString();
+    }
+
+    // ---------- Rendering ----------
     function formatDate(dateString) {
       if (!dateString) return '-';
-      
-      // Check if it's a Unix timestamp (number of milliseconds)
       if (typeof dateString === 'number') {
-        // Excel serial date conversion (days since 1900-01-01)
         if (dateString > 10000 && dateString < 100000) {
           const excelEpoch = new Date(1900, 0, 1);
           const date = new Date(excelEpoch.getTime() + (dateString - 2) * 86400000);
           return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
         }
-        // Unix timestamp in seconds
         if (dateString > 1000000000 && dateString < 10000000000) {
-          const date = new Date(dateString * 1000);
-          return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+          return new Date(dateString * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
         }
-        // Unix timestamp in milliseconds
         if (dateString > 1000000000000) {
-          const date = new Date(dateString);
-          return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+          return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
         }
       }
-      
-      // Try parsing as ISO date string
       const date = new Date(dateString);
-      if (isNaN(date.getTime())) return dateString; // Return as-is if can't parse
-      
+      if (Number.isNaN(date.getTime())) return dateString;
       return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     }
 
-    // Search functionality
+    function monthKey(dateString) {
+      let date;
+      if (typeof dateString === 'number') {
+        if (dateString > 10000 && dateString < 100000) {
+          date = new Date(new Date(1900, 0, 1).getTime() + (dateString - 2) * 86400000);
+        } else if (dateString > 1000000000 && dateString < 10000000000) {
+          date = new Date(dateString * 1000);
+        } else {
+          date = new Date(dateString);
+        }
+      } else {
+        date = new Date(dateString);
+      }
+      if (Number.isNaN(date.getTime())) return null;
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    }
+
+    function renderBars(containerId, entries) {
+      const container = document.getElementById(containerId);
+      if (!entries.length) {
+        container.innerHTML = '<p class="muted">No data yet.</p>';
+        return;
+      }
+      const max = Math.max(...entries.map((e) => e.value)) || 1;
+      container.innerHTML = entries.map((e) => `
+        <div class="bar-row">
+          <span class="bar-label" title="${e.label}">${e.label}</span>
+          <span class="bar-track"><span class="bar-fill" style="width:${Math.max(2, (e.value / max) * 100)}%"></span></span>
+          <span class="bar-value">${e.value.toLocaleString()}</span>
+        </div>`).join('');
+    }
+
+    function renderAuthorBars() {
+      const byAuthor = {};
+      articles.forEach((a) => {
+        if (!byAuthor[a.author]) byAuthor[a.author] = { claps: 0, count: 0 };
+        byAuthor[a.author].claps += a.totalClaps || 0;
+        byAuthor[a.author].count += 1;
+      });
+      const entries = Object.entries(byAuthor)
+        .map(([label, v]) => ({ label: `${label} (${v.count})`, value: v.claps }))
+        .sort((a, b) => b.value - a.value)
+        .slice(0, 10);
+      renderBars('authorBars', entries);
+    }
+
+    function renderTopicBars() {
+      const byTag = {};
+      articles.forEach((a) => {
+        a.tags.forEach((t) => {
+          if (!byTag[t]) byTag[t] = 0;
+          byTag[t] += a.totalClaps || 0;
+        });
+      });
+      const entries = Object.entries(byTag)
+        .map(([label, value]) => ({ label, value }))
+        .sort((a, b) => b.value - a.value)
+        .slice(0, 10);
+      renderBars('topicBars', entries);
+    }
+
+    function renderCadenceBars() {
+      const byMonth = {};
+      articles.forEach((a) => {
+        const k = monthKey(a.date);
+        if (!k) return;
+        byMonth[k] = (byMonth[k] || 0) + 1;
+      });
+      const entries = Object.entries(byMonth)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .slice(-18)
+        .map(([label, value]) => ({ label, value }));
+      renderBars('cadenceBars', entries);
+    }
+
+    function sortArticles(sortBy) {
+      sortDirection = currentSort === sortBy && sortDirection === 'desc' ? 'asc' : 'desc';
+      currentSort = sortBy;
+      renderTable();
+    }
+
+    function sortedArticles(list) {
+      const dir = sortDirection === 'desc' ? -1 : 1;
+      return [...list].sort((a, b) => {
+        let av; let bv;
+        if (currentSort === 'date') { av = new Date(a.date).getTime() || 0; bv = new Date(b.date).getTime() || 0; }
+        else if (currentSort === 'velocity') { av = velocityOf(a); bv = velocityOf(b); }
+        else if (currentSort === 'engagement') { av = engagementOf(a) || -1; bv = engagementOf(b) || -1; }
+        else if (currentSort === 'views') { av = a.views || -1; bv = b.views || -1; }
+        else if (currentSort === 'totalClaps') { av = a.totalClaps || 0; bv = b.totalClaps || 0; }
+        else if (currentSort === 'author') { return dir * String(a.author).localeCompare(String(b.author)); }
+        else { return dir * String(a.title).localeCompare(String(b.title)); }
+        return dir * (av - bv);
+      });
+    }
+
+    function renderTable(filtered = articles) {
+      const tbody = document.getElementById('tableBody');
+      const rows = sortedArticles(filtered);
+      if (rows.length === 0) {
+        document.getElementById('articlesTable').style.display = 'none';
+        document.getElementById('noResults').style.display = 'block';
+        return;
+      }
+      document.getElementById('articlesTable').style.display = 'table';
+      document.getElementById('noResults').style.display = 'none';
+
+      tbody.innerHTML = rows.map((a) => {
+        const eng = engagementOf(a);
+        const viewsCell = a.views === null ? '<span class="muted">—</span>' : Math.round(a.views).toLocaleString();
+        const engCell = eng === null ? '<span class="muted">—</span>' : eng.toFixed(1);
+        const tagsHtml = a.tags.slice(0, 3).map((t) => `<span class="tag">${t}</span>`).join('');
+        return `
+          <tr>
+            <td>
+              <div class="article-title">${a.title}</div>
+              <a href="${a.path}" target="_blank" class="article-link">${a.path}</a>
+              <div>${tagsHtml}</div>
+            </td>
+            <td>${a.author}</td>
+            <td><span class="muted">${formatDate(a.date)}</span></td>
+            <td class="numeric"><span class="${(a.totalClaps || 0) > 10 ? 'claps-count' : ''}">${(a.totalClaps || 0).toLocaleString()}</span></td>
+            <td class="numeric">${velocityOf(a).toFixed(2)}</td>
+            <td class="numeric">${viewsCell}</td>
+            <td class="numeric">${engCell}</td>
+          </tr>`;
+      }).join('');
+
+      document.querySelectorAll('th .sort-indicator').forEach((i) => { i.textContent = ''; });
+      const activeTh = document.querySelector(`th[data-sort="${currentSort}"]`);
+      if (activeTh) {
+        const indicator = activeTh.querySelector('.sort-indicator');
+        if (indicator) indicator.textContent = sortDirection === 'desc' ? '▼' : '▲';
+      }
+    }
+
+    // ---------- Events ----------
     document.getElementById('searchBox').addEventListener('input', (e) => {
-      const searchTerm = e.target.value.toLowerCase();
-      const filtered = articles.filter(article => 
-        article.title.toLowerCase().includes(searchTerm) ||
-        article.path.toLowerCase().includes(searchTerm) ||
-        article.description.toLowerCase().includes(searchTerm)
-      );
-      renderTable(filtered);
+      const term = e.target.value.toLowerCase();
+      renderTable(articles.filter((a) => a.title.toLowerCase().includes(term)
+        || a.path.toLowerCase().includes(term)
+        || a.author.toLowerCase().includes(term)
+        || a.tags.join(' ').toLowerCase().includes(term)));
     });
 
-    // Sort button handlers
-    document.querySelectorAll('.filter-btn').forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
-        e.target.classList.add('active');
-        sortArticles(e.target.dataset.sort);
-      });
+    document.querySelectorAll('th[data-sort]').forEach((th) => {
+      th.addEventListener('click', () => sortArticles(th.dataset.sort));
     });
 
-    // Table header click handlers
-    document.querySelectorAll('th[data-sort]').forEach(th => {
-      th.addEventListener('click', () => {
-        sortArticles(th.dataset.sort);
-      });
+    document.getElementById('loadRumBtn').addEventListener('click', loadPageViews);
+    document.getElementById('forgetKeyBtn').addEventListener('click', () => {
+      localStorage.removeItem('rum-domainkey');
+      document.getElementById('rumKey').value = '';
+      document.getElementById('rumStatus').textContent = 'Domainkey cleared from this browser.';
+      document.getElementById('rumStatus').className = 'rum-status';
     });
 
-    // Load data on page load
+    // Prefill RUM config
+    document.getElementById('rumDomain').value = localStorage.getItem('rum-domain') || window.location.hostname;
+    document.getElementById('rumKey').value = localStorage.getItem('rum-domainkey') || '';
+
     loadData();
   </script>
 </body>


### PR DESCRIPTION
Extends the admin analytics dashboard (`/admin/claps-analytics.html`) beyond "total articles + total claps" with stats derived from the article index, the claps API, and AEM's built-in RUM.

## New summary cards
- **Avg / median claps per article**
- **Authors** count
- **Total page views** (once RUM is loaded)

## Main table
Now shows, per article (all columns sortable):
- **Author** and **tags** (from `query-index.json` — already indexed in `helix-query.yaml`, just unused before)
- **Clap velocity** — claps ÷ days since publish (surfaces new posts outperforming their age, which a raw total hides)
- **Page views** and **engagement** (claps per 1k views)

## Charts
- **Top authors** and **top topics** by total claps
- **Publishing cadence** — articles per month

## Page views (AEM RUM)
Pulls real page views from AEM's RUM bundler API (`rum.hlx.page/bundles/...`), aggregated per article path by summing bundle weights over a selectable range (7/30/90 days). Views are **weighted/sampled estimates** and labelled as such.

The RUM **domainkey** is a secret, so — important for a public repo — it is **entered in the UI and stored only in the browser's localStorage**, never hardcoded or committed. A "Forget key" button clears it.

## Cleanup
Removed the `uniqueUsers` field, which was always 0 (the applause API only returns a single total).

## Verification
- Inline script passes `node --check` (no syntax errors).
- 15 unit tests on the pure helpers pass: tag parsing (all 3 index shapes), median, RUM path normalization + weighted aggregation, engagement/velocity math, month bucketing.
- Live browser render couldn't be exercised locally (content origin is auth-gated, RUM needs the secret key) — those paths are covered by the logic tests above and degrade gracefully (empty states, error messages on bad key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)