### PR TITLE
fix: use correct AEM RUM bundler host (bundles.aem.page)

### DIFF
--- a/admin/claps-analytics.html
+++ b/admin/claps-analytics.html
@@ -554,7 +554,8 @@
 
     // ---------- Page views (AEM RUM) ----------
     function rumUrl(domain, year, month, day, key) {
-      return `https://rum.hlx.page/bundles/${domain}/${year}/${month}/${day}?domainkey=${encodeURIComponent(key)}`;
+      // AEM RUM bundler (same endpoint the official RUM Explorer uses)
+      return `https://bundles.aem.page/bundles/${domain}/${year}/${month}/${day}?domainkey=${encodeURIComponent(key)}`;
     }
 
     async function fetchRumDay(domain, key, d) {


### PR DESCRIPTION
Follow-up to #126. The page-views feature failed with "all requests failed" because the dashboard queried `rum.hlx.page`, which returns HTTP 400.

Switches to **`bundles.aem.page`** — the host AEM's official RUM Explorer uses.

### Verified (without the secret domainkey)
- `bundles.aem.page/bundles/culture-tecture.adobe.com/2026/6/22?domainkey=<bad>` → **403** (auth rejection, so host + path are correct; a valid key returns 200)
- old `rum.hlx.page` → **400** (confirming it was the culprit)
- CORS: `access-control-allow-origin: *`, so the browser fetch from the dashboard is allowed

One-line host change; inline script passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)