### PR TITLE
feat: auto-load RUM page views when a domainkey is saved

### DIFF
--- a/admin/claps-analytics.html
+++ b/admin/claps-analytics.html
@@ -525,6 +525,12 @@
       document.getElementById('loading').style.display = 'none';
       document.getElementById('articlesTable').style.display = 'table';
 
+      // Auto-load page views if a domainkey is already saved in this browser,
+      // so the user doesn't have to click "Load page views" on every visit.
+      if (localStorage.getItem('rum-domainkey')) {
+        loadPageViews();
+      }
+
       await fetchAllClaps();
     }
 


### PR DESCRIPTION
Follow-up to the dashboard work (#126/#127).

The RUM domainkey already persists in `localStorage` and prefills the field, but you still had to click **Load page views** on every visit. This auto-fetches page views on page load whenever a saved key is present — running concurrently with the claps fetch so it doesn't slow the initial render. The button stays for manual refresh and changing the date range.

One-line behavioral change in `loadData()`; inline script passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)