### PR TITLE
feat: Adobe-brand restyle + date fix for articles dashboard

### DIFF
--- a/admin/claps-analytics.html
+++ b/admin/claps-analytics.html
@@ -27,13 +27,15 @@
       background: white;
       padding: 30px;
       border-radius: 12px;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      border: 1px solid #e1e1e1;
       margin-bottom: 30px;
     }
 
     .header h1 {
-      color: #333;
+      color: #2c2c2c;
       font-size: 2.5rem;
+      font-weight: 800;
+      letter-spacing: -0.02em;
       margin-bottom: 10px;
     }
 
@@ -50,10 +52,10 @@
     }
 
     .stat-card {
-      background: #2c3e50;
+      background: #000000;
       padding: 25px;
       border-radius: 12px;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      border: 1px solid #e1e1e1;
       text-align: center;
     }
 
@@ -66,7 +68,7 @@
 
     .stat-card .label {
       font-size: 0.95rem;
-      color: #ecf0f1;
+      color: #e6e6e6;
       text-transform: uppercase;
       letter-spacing: 1px;
     }
@@ -75,15 +77,28 @@
       background: white;
       padding: 30px;
       border-radius: 12px;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      border: 1px solid #e1e1e1;
       overflow-x: auto;
       margin-bottom: 30px;
     }
 
     .panel h2 {
-      color: #333;
+      color: #2c2c2c;
       font-size: 1.4rem;
       margin-bottom: 6px;
+    }
+
+    details.panel > summary {
+      cursor: pointer;
+      font-size: 1.2rem;
+      font-weight: 700;
+      color: #2c2c2c;
+      letter-spacing: -0.01em;
+      list-style-position: inside;
+    }
+
+    details.panel[open] > summary {
+      margin-bottom: 16px;
     }
 
     .panel .panel-hint {
@@ -131,13 +146,13 @@
     .rum-config input:focus,
     .rum-config select:focus {
       outline: none;
-      border-color: #667eea;
+      border-color: #EB1000;
     }
 
     .btn {
       padding: 11px 22px;
-      border: 2px solid #667eea;
-      background: #667eea;
+      border: 2px solid #EB1000;
+      background: #EB1000;
       color: white;
       border-radius: 8px;
       cursor: pointer;
@@ -147,12 +162,12 @@
     }
 
     .btn:hover {
-      background: #5568d3;
+      background: #C20D00;
     }
 
     .btn.secondary {
       background: white;
-      color: #667eea;
+      color: #EB1000;
     }
 
     .rum-status {
@@ -185,7 +200,7 @@
 
     .search-box:focus {
       outline: none;
-      border-color: #667eea;
+      border-color: #EB1000;
     }
 
     table {
@@ -232,7 +247,7 @@
 
     .claps-count {
       font-weight: bold;
-      color: #667eea;
+      color: #EB1000;
     }
 
     .article-title {
@@ -242,7 +257,7 @@
     }
 
     .article-link {
-      color: #1473E6;
+      color: #EB1000;
       text-decoration: none;
       font-size: 0.85rem;
       word-break: break-all;
@@ -259,8 +274,8 @@
 
     .tag {
       display: inline-block;
-      background: #eef0fb;
-      color: #4a57c9;
+      background: #f0f0f0;
+      color: #2c2c2c;
       border-radius: 6px;
       padding: 2px 8px;
       font-size: 0.78rem;
@@ -284,14 +299,14 @@
     }
 
     .bar-track {
-      background: #eef0fb;
+      background: #f0f0f0;
       border-radius: 6px;
       height: 18px;
       overflow: hidden;
     }
 
     .bar-fill {
-      background: #667eea;
+      background: #EB1000;
       height: 100%;
       border-radius: 6px;
     }
@@ -305,7 +320,7 @@
     .big-metric {
       font-size: 3rem;
       font-weight: bold;
-      color: #667eea;
+      color: #EB1000;
       line-height: 1.1;
     }
 
@@ -318,7 +333,7 @@
 
     .spinner {
       border: 4px solid #f3f3f3;
-      border-top: 4px solid #667eea;
+      border-top: 4px solid #EB1000;
       border-radius: 50%;
       width: 40px;
       height: 40px;
@@ -378,12 +393,12 @@
     </div>
 
     <!-- Page views (RUM) configuration -->
-    <div class="panel">
-      <h2>📈 Page views (AEM RUM)</h2>
+    <details class="panel" id="rumPanel">
+      <summary>Page views settings (AEM RUM)</summary>
       <p class="panel-hint">
         Real page-view data comes from AEM's built-in Real User Monitoring. It needs the domain's
         <strong>RUM domainkey</strong> (a secret) &mdash; it is stored only in this browser (localStorage), never sent anywhere except the RUM API.
-        Views are weighted/sampled estimates.
+        Views are weighted/sampled estimates. Once the key is saved you can leave this collapsed; views load automatically.
       </p>
       <div class="rum-config">
         <div class="field">
@@ -406,7 +421,7 @@
         <button class="btn secondary" id="forgetKeyBtn">Forget key</button>
       </div>
       <div class="rum-status" id="rumStatus"></div>
-    </div>
+    </details>
 
     <!-- Main articles table -->
     <div class="panel">
@@ -428,9 +443,8 @@
             <th class="numeric" data-sort="totalClaps">Claps<span class="sort-indicator"></span></th>
             <th class="numeric" data-sort="velocity">Claps/day<span class="sort-indicator"></span></th>
             <th class="numeric" data-sort="views">Views<span class="sort-indicator"></span></th>
-            <th class="numeric" data-sort="engagement">Claps/1k views<span class="sort-indicator"></span></th>
+            <th class="numeric" data-sort="engagement" title="Claps per 1,000 page views — claps normalised by traffic, so small and large posts compare fairly">Claps / 1k views<span class="sort-indicator"></span></th>
             <th class="numeric" data-sort="mobile">Mobile %<span class="sort-indicator"></span></th>
-            <th class="numeric" data-sort="engaged">Engaged %<span class="sort-indicator"></span></th>
           </tr>
         </thead>
         <tbody id="tableBody"></tbody>
@@ -754,9 +768,9 @@
     }
 
     function daysSince(date) {
-      const t = new Date(date).getTime();
-      if (Number.isNaN(t)) return null;
-      return Math.max(1, (Date.now() - t) / 86400000);
+      const d = toDate(date);
+      if (!d) return null;
+      return Math.max(1, (Date.now() - d.getTime()) / 86400000);
     }
 
     function velocityOf(article) {
@@ -777,11 +791,6 @@
       return (article.rum.mobile / human) * 100;
     }
 
-    function engagedPctOf(article) {
-      if (!article.rum || article.rum.views <= 0) return null;
-      return (article.rum.engaged / article.rum.views) * 100;
-    }
-
     function updateStats() {
       const totalArticles = articles.length;
       const totalClaps = articles.reduce((sum, a) => sum + (a.totalClaps || 0), 0);
@@ -796,41 +805,44 @@
     }
 
     // ---------- Rendering ----------
-    function formatDate(dateString) {
-      if (!dateString) return '-';
-      if (typeof dateString === 'number') {
-        if (dateString > 10000 && dateString < 100000) {
-          const excelEpoch = new Date(1900, 0, 1);
-          const date = new Date(excelEpoch.getTime() + (dateString - 2) * 86400000);
-          return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-        }
-        if (dateString > 1000000000 && dateString < 10000000000) {
-          return new Date(dateString * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-        }
-        if (dateString > 1000000000000) {
-          return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    // Normalise the many shapes the query-index date can take into a JS Date.
+    // The index serves dates as a numeric STRING (Excel serial days), which a
+    // bare `new Date(str)` mis-parses as a far-future year (e.g. "Jan 1, 46195").
+    function toDate(value) {
+      if (value === null || value === undefined || value === '') return null;
+      let v = value;
+      if (typeof v === 'string') {
+        const t = v.trim();
+        if (/^\d+$/.test(t)) {
+          v = parseInt(t, 10); // numeric string -> treat as a number below
+        } else {
+          const d = new Date(t);
+          return Number.isNaN(d.getTime()) ? null : d;
         }
       }
-      const date = new Date(dateString);
-      if (Number.isNaN(date.getTime())) return dateString;
-      return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+      if (typeof v === 'number') {
+        if (v > 10000 && v < 100000) {
+          // Excel/Sheets serial: days since 1899-12-30
+          return new Date(new Date(1900, 0, 1).getTime() + (v - 2) * 86400000);
+        }
+        if (v > 1000000000 && v < 10000000000) return new Date(v * 1000); // unix seconds
+        if (v >= 1000000000000) return new Date(v); // unix milliseconds
+        return null;
+      }
+      const d = new Date(v);
+      return Number.isNaN(d.getTime()) ? null : d;
     }
 
-    function monthKey(dateString) {
-      let date;
-      if (typeof dateString === 'number') {
-        if (dateString > 10000 && dateString < 100000) {
-          date = new Date(new Date(1900, 0, 1).getTime() + (dateString - 2) * 86400000);
-        } else if (dateString > 1000000000 && dateString < 10000000000) {
-          date = new Date(dateString * 1000);
-        } else {
-          date = new Date(dateString);
-        }
-      } else {
-        date = new Date(dateString);
-      }
-      if (Number.isNaN(date.getTime())) return null;
-      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    function formatDate(value) {
+      const d = toDate(value);
+      if (!d) return '-';
+      return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+
+    function monthKey(value) {
+      const d = toDate(value);
+      if (!d) return null;
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
     }
 
     function renderBars(containerId, entries) {
@@ -901,12 +913,11 @@
       const dir = sortDirection === 'desc' ? -1 : 1;
       return [...list].sort((a, b) => {
         let av; let bv;
-        if (currentSort === 'date') { av = new Date(a.date).getTime() || 0; bv = new Date(b.date).getTime() || 0; }
+        if (currentSort === 'date') { av = (toDate(a.date) || new Date(0)).getTime(); bv = (toDate(b.date) || new Date(0)).getTime(); }
         else if (currentSort === 'velocity') { av = velocityOf(a); bv = velocityOf(b); }
         else if (currentSort === 'engagement') { av = engagementOf(a) || -1; bv = engagementOf(b) || -1; }
         else if (currentSort === 'views') { av = a.views || -1; bv = b.views || -1; }
         else if (currentSort === 'mobile') { av = mobilePctOf(a) ?? -1; bv = mobilePctOf(b) ?? -1; }
-        else if (currentSort === 'engaged') { av = engagedPctOf(a) ?? -1; bv = engagedPctOf(b) ?? -1; }
         else if (currentSort === 'totalClaps') { av = a.totalClaps || 0; bv = b.totalClaps || 0; }
         else if (currentSort === 'author') { return dir * String(a.author).localeCompare(String(b.author)); }
         else { return dir * String(a.title).localeCompare(String(b.title)); }
@@ -928,11 +939,9 @@
       tbody.innerHTML = rows.map((a) => {
         const eng = engagementOf(a);
         const mob = mobilePctOf(a);
-        const engaged = engagedPctOf(a);
         const viewsCell = a.views === null ? '<span class="muted">—</span>' : Math.round(a.views).toLocaleString();
         const engCell = eng === null ? '<span class="muted">—</span>' : eng.toFixed(1);
         const mobCell = mob === null ? '<span class="muted">—</span>' : `${mob.toFixed(0)}%`;
-        const engagedCell = engaged === null ? '<span class="muted">—</span>' : `${engaged.toFixed(0)}%`;
         const tagsHtml = a.tags.slice(0, 3).map((t) => `<span class="tag">${t}</span>`).join('');
         return `
           <tr>
@@ -948,7 +957,6 @@
             <td class="numeric">${viewsCell}</td>
             <td class="numeric">${engCell}</td>
             <td class="numeric">${mobCell}</td>
-            <td class="numeric">${engagedCell}</td>
           </tr>`;
       }).join('');
 
@@ -979,11 +987,15 @@
       document.getElementById('rumKey').value = '';
       document.getElementById('rumStatus').textContent = 'Domainkey cleared from this browser.';
       document.getElementById('rumStatus').className = 'rum-status';
+      document.getElementById('rumPanel').open = true;
     });
 
-    // Prefill RUM config
+    // Prefill RUM config; expand the settings only if no key is saved yet
     document.getElementById('rumDomain').value = localStorage.getItem('rum-domain') || window.location.hostname;
     document.getElementById('rumKey').value = localStorage.getItem('rum-domainkey') || '';
+    if (!localStorage.getItem('rum-domainkey')) {
+      document.getElementById('rumPanel').open = true;
+    }
 
     loadData();
   </script>


### PR DESCRIPTION
Addresses the dashboard feedback.

### 1. Adobe brand styling
Re-themed to the Adobe Brand Guidelines: **red `#EB1000` / black / white only**. Replaces the off-brand indigo accents and navy stat cards with black cards + red accents, drops shadow tints in favour of clean borders, and tightens the headline.

### 2. Date format fixed (was "Jan 1, 46195")
The query-index serves dates as a numeric **string** (Excel serial days); a bare `new Date(str)` mis-parsed those as a far-future year. New shared `toDate()` helper handles serial / unix / ISO and is reused by `formatDate`, `monthKey`, `daysSince`, and the date-column sort. This also fixes **claps/day velocity**, which was being clamped to 1 day (now correctly ~0.71 for an 8-day-old post).

### 3. "Claps / 1k views" explained
Added a column tooltip: *claps per 1,000 page views — normalised by traffic so small and large posts compare fairly.*

### 4. Removed the per-article "Engaged %" column
(The site-wide engagement panel stays.)

### Bonus — domainkey panel ("do I still need it?")
You need the key once (it's a secret, can't be committed). It already persisted in localStorage and auto-loads; now the whole settings block is a collapsed `<details>` that only auto-expands when no key is saved — so it's out of your way day to day.

### Verification
- Inline script passes `node --check`; no leftover old colours or removed-symbol references.
- Unit tests: `toDate`/`formatDate`/`monthKey` (incl. the exact `"46195"` bug input → "Jun 22, 2026").
- **Visually verified** by serving the page locally with mock data — screenshots confirm the Adobe palette, corrected dates, corrected velocity, the tooltip, and the dropped column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)