### PR TITLE
chore: rename dashboard to 'Blog & AI CoC Dashboard'

### DIFF
--- a/admin/claps-analytics.html
+++ b/admin/claps-analytics.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Articles Dashboard</title>
+  <title>Blog &amp; AI CoC Dashboard</title>
   <style>
     * {
       margin: 0;
@@ -463,7 +463,7 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>📚 Articles Dashboard</h1>
+      <h1>📚 Blog &amp; AI CoC Dashboard</h1>
       <p>Blog &amp; AI CoC engagement and publishing analytics</p>
     </div>
 


### PR DESCRIPTION
Renames the dashboard from "Articles Dashboard" to **"Blog & AI CoC Dashboard"** (both the browser `<title>` and the on-page `<h1>`), now that it covers both sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)