### PR TITLE
feat: shared RUM domainkey via published config sheet

### DIFF
--- a/admin/claps-analytics.html
+++ b/admin/claps-analytics.html
@@ -772,9 +772,9 @@
       // Load the independent AI CoC section (sessions + manual stats sheet).
       loadAiCoC();
 
-      // Auto-load page views if a domainkey is already saved in this browser,
-      // so the user doesn't have to click "Load page views" on every visit.
-      if (localStorage.getItem('rum-domainkey')) {
+      // Auto-load page views whenever a key is available — from the shared
+      // config sheet (set during init) or a key saved in this browser.
+      if (document.getElementById('rumKey').value.trim()) {
         loadPageViews();
       }
 
@@ -1400,14 +1400,34 @@
       document.getElementById('rumPanel').open = true;
     });
 
-    // Prefill RUM config; expand the settings only if no key is saved yet
-    document.getElementById('rumDomain').value = localStorage.getItem('rum-domain') || window.location.hostname;
-    document.getElementById('rumKey').value = localStorage.getItem('rum-domainkey') || '';
-    if (!localStorage.getItem('rum-domainkey')) {
-      document.getElementById('rumPanel').open = true;
+    // Shared RUM key: read from a published config sheet so every (SSO-authenticated)
+    // visitor gets data without entering the key. The secret lives in SharePoint behind
+    // the same login — never in this public repo. Falls back to a locally-saved key.
+    async function fetchDashboardConfig() {
+      try {
+        const res = await fetch('/en/dashboard-config.json');
+        if (!res.ok) return {};
+        const data = await res.json();
+        const row = (data.data || [])[0] || {};
+        return {
+          domainkey: row.domainkey || row.domainKey || row.rumdomainkey || '',
+          domain: row.domain || '',
+        };
+      } catch (e) {
+        return {};
+      }
     }
 
-    loadData();
+    (async function init() {
+      const cfg = await fetchDashboardConfig();
+      const domain = cfg.domain || localStorage.getItem('rum-domain') || window.location.hostname;
+      const key = cfg.domainkey || localStorage.getItem('rum-domainkey') || '';
+      document.getElementById('rumDomain').value = domain;
+      document.getElementById('rumKey').value = key;
+      // Only nag for manual entry when no key is available from anywhere.
+      if (!key) document.getElementById('rumPanel').open = true;
+      loadData();
+    }());
   </script>
 </body>
 </html>


### PR DESCRIPTION
So every (SSO-authenticated) visitor sees page-view data without entering the domainkey, and without storing a secret in this **public** repo.

## How
On load, the dashboard fetches `/en/dashboard-config.json` and uses its `domainkey` automatically. Because the whole site is behind Adobe SSO, that sheet is readable only by people who can already open the dashboard — so the key reaches exactly the intended audience and **never goes into public GitHub**. Falls back to a locally-saved or manually-entered key if the sheet isn't present.

## What you need to publish (one-time)
A tiny AEM sheet at `content/en/dashboard-config.xlsx` → `/en/dashboard-config.json`, one row:

| domainkey | domain |
|---|---|
| `<your culture-tecture RUM domainkey>` | culture-tecture.adobe.com |

(`domain` is optional; defaults to the current host. Header names `domainKey`/`rumdomainkey` are also accepted.)

## Security note
The domainkey is already visible to any dashboard user in their browser's Network tab once views load, so exposing it to that same SSO-gated audience via the sheet changes nothing — but it keeps the secret out of the public repo. **Do not** commit the key to the repo.

## Verification
- Inline script passes `node --check`.
- Logic: with the sheet present, the key auto-applies and page views load on first visit in any browser (no localStorage needed); without it, behaviour is unchanged (manual entry, remembered per-browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)