### PR TITLE
feat: show site header (gnav) + footer on the dashboard

### DIFF
--- a/admin/claps-analytics.html
+++ b/admin/claps-analytics.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Blog &amp; AI CoC Dashboard</title>
+  <!-- Site styles so the shared header (gnav) and footer render correctly.
+       Loaded before the dashboard's own styles below, so the dashboard wins on conflicts. -->
+  <link rel="stylesheet" href="/styles/styles.css"/>
   <style>
     * {
       margin: 0;
@@ -12,6 +15,9 @@
     }
 
     body {
+      /* styles.css hides the body until the full boilerplate adds .appear;
+         we don't run that pipeline, so reveal it here. */
+      display: block;
       font-family: 'Adobe Clean', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: #f5f5f5;
       min-height: 100vh;
@@ -461,6 +467,7 @@
   </style>
 </head>
 <body>
+  <header></header>
   <div class="container">
     <div class="header">
       <h1>📚 Blog &amp; AI CoC Dashboard</h1>
@@ -1411,6 +1418,24 @@
       }
       loadData();
     }());
+  </script>
+
+  <footer></footer>
+
+  <!-- Load the site's shared header (gnav) and footer, exactly as regular pages do,
+       without running the full page pipeline (which would re-decorate the dashboard). -->
+  <script type="module">
+    import { loadBlock, loadFooter } from '/scripts/lib-franklin.js';
+    // styles.css hides the body until '.appear' is added by the boilerplate; reveal it.
+    document.body.classList.add('appear');
+    document.body.style.display = 'block';
+    window.hlx = window.hlx || {};
+    if (window.hlx.codeBasePath === undefined) window.hlx.codeBasePath = '';
+    const header = document.querySelector('header');
+    header.setAttribute('data-block-name', 'gnav');
+    header.setAttribute('data-gnav-source', '/en/gnav');
+    loadBlock(header);
+    loadFooter(document.querySelector('footer'));
   </script>
 </body>
 </html>


### PR DESCRIPTION
Adds the normal site navigation (and footer) to the analytics dashboard, so it matches the rest of culture-tecture / re-think.

## Why it was missing
`admin/claps-analytics.html` is a standalone HTML file served *outside* AEM's page-rendering pipeline, so it never got the header/footer that the boilerplate injects on authored pages.

## How
Reproduces exactly what regular pages do, but in a controlled way:
- Imports `loadBlock` / `loadFooter` from `lib-franklin.js` and decorates a `<header>` (the `gnav` block, source `/en/gnav`) and `<footer>` (`/footer`).
- Does **not** run the full `scripts.js` page pipeline — that would try to re-decorate the dashboard's bespoke markup (sections, buttons, blocks) and break the layout.
- Loads `/styles/styles.css` (before the dashboard's own `<style>`, so the dashboard wins on conflicts) for nav/footer styling, and reveals the body (`styles.css` hides it until the boilerplate adds `.appear`, which we now do).

## Verification
- Main inline script passes `node --check`.
- Verified locally (static server over the repo): `styles.css` + the gnav/footer blocks load **without breaking the dashboard layout** — title, KPI strip, tabs, and cards all render correctly, with the header bar reserved at top.
- ⚠️ The nav **content** (`/en/gnav.plain.html`) is authored content behind SSO, so it 404s on my local server and can't be shown here — it will populate on the real domain. Please eyeball it once deployed to confirm the nav looks right; if the spacing/full-width needs tweaking against the real nav, that's a quick follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)