### PR TITLE
fix: halve gap between article hero image and body text

### DIFF
--- a/blocks/article-header/article-header.css
+++ b/blocks/article-header/article-header.css
@@ -13,6 +13,21 @@ main .section-wrapper .article-header {
   max-width: unset;
 }
 
+/* halve the gap between the feature image and the body copy that follows it */
+main .section.article-header-container {
+  padding-bottom: 32px;
+}
+
+main .article-header-container + .section {
+  margin-top: 32px;
+}
+
+@media (min-width: 600px) {
+  main .article-header-container + .section {
+    padding-top: 32px;
+  }
+}
+
 @media (min-width: 700px) {
   main .article-header {
     margin-left: auto;


### PR DESCRIPTION
## Problem

On blog post pages, the vertical gap between the feature/hero image and the first paragraph of body text was much larger than intended (~192px on desktop/tablet, 64px on mobile).

## Cause

The hero image and the body copy render as two separate `main .section` elements. Generic section spacing rules in `styles/styles.css` stack up between them:

- hero section: `padding-bottom: 64px`
- body section: `margin-top: 64px` + `padding-top: 64px`

## Fix

Added a scoped rule in `blocks/article-header/article-header.css` targeting only the article-header section and the section immediately following it, halving each contributing value (64px → 32px). This keeps the change local to the hero-image-to-body transition and doesn't affect spacing between other sections on this or other pages.

Result: gap goes from ~192px → ~96px on desktop/tablet, and 64px → 32px on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)